### PR TITLE
feat: Replicate backend, research-driven prompt improvements, official spec updates

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "banana-claude",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "AI image generation Creative Director powered by Google Gemini Nano Banana models. Claude interprets intent, selects domain expertise, constructs optimized prompts, and orchestrates Gemini for best results.",
   "author": {
     "name": "AgriciDaniel",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.2] - 2026-03-27
+
+### Added
+- **Replicate backend** -- `google/nano-banana-2` as alternative to MCP and Direct Gemini API
+  - `scripts/replicate_generate.py` -- stdlib-only generation script
+  - `scripts/replicate_edit.py` -- stdlib-only editing script
+  - `references/replicate.md` -- full reference doc with params, pricing, error handling
+- **5-Input Creative Brief** system in SKILL.md (Purpose, Audience, Subject, Brand, References)
+- **Edit-First principle** elevated to core principle with edit-vs-regenerate decision matrix
+- **Three Prompt Variations** (Literal/Creative/Premium) for `/banana batch`
+- **Quality Checklist** in response verification step
+- **PEEL Strategy** for structured spec refinement (Position, Expression, Environment, Lens)
+- **Progressive Enhancement** 4-phase workflow for `/banana chat` sessions
+- **Multilingual & Localization** section in prompt-engineering.md
+- **Expanded Character Consistency** (identity-locked patterns, group photos, storytelling)
+- **5 new Common Pitfalls** (contradictory instructions, impossible physics, style mixing, etc.)
+- **Expanded Search Grounding** with practical examples table
+- **Resolution pixel dimension tables** for all aspect ratios at 512/1K/2K/4K
+- **Input Limits section** in gemini-models.md (14 images, 7MB inline, 500MB total, HEIC/HEIF)
+- **Watermark Behavior by Tier** table (SynthID, visible sparkle, C2PA)
+- **Thinking Visibility** docs (`includeThoughts`, thought images)
+- `setup_mcp.py` now supports `--replicate-key` and `--check-replicate`
+- Replicate pricing in cost_tracker.py and cost-tracking.md
+
+### Changed
+- Prompt engineering approach: "Start with Intent, Refine with Specs" (PEEL strategy)
+- Fallback chain: MCP → Direct Gemini API → Replicate
+- Output tokens per image corrected to up to ~2,520 (was ~1,290)
+
+### Fixed
+- Free tier rate limits in cost-tracking.md corrected to ~5-15 RPM / ~20-500 RPD (was ~10 / ~500)
+
 ## [1.4.1] - 2026-03-27
 
 ### Changed
@@ -117,6 +149,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Batch variations, multi-turn chat, prompt inspiration
 - Install script with validation
 
+[1.4.2]: https://github.com/AgriciDaniel/banana-claude/releases/tag/v1.4.2
+[1.4.1]: https://github.com/AgriciDaniel/banana-claude/releases/tag/v1.4.1
 [1.4.0]: https://github.com/AgriciDaniel/banana-claude/releases/tag/v1.4.0
 [1.3.0]: https://github.com/AgriciDaniel/banana-claude/releases/tag/v1.3.0
 [1.2.0]: https://github.com/AgriciDaniel/banana-claude/releases/tag/v1.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.0] - 2026-04-06
+
+### Added
+- **Presentation domain mode** with two generation options:
+  - **Complete Slide** -- model renders headline/body text directly (leverages Nano Banana 2's 94% text accuracy)
+  - **Background Only** -- clean backgrounds with negative space for layering in Keynote/PPT/Slides
+- **Brand Style Guides** -- 8 new optional preset fields for project-wide visual consistency:
+  - `background_styles` -- named background variants (dark-premium, gradient, split-layout)
+  - `visual_motifs` -- pattern overlays with opacity
+  - `prompt_suffix` -- appended verbatim to every prompt
+  - `prompt_keywords` -- categorized keywords woven into prompts
+  - `do_list` / `dont_list` -- brand guardrails checked before generation
+  - `logo_placement` -- records post-production logo position (never mentioned in prompts)
+  - `technical_specs` -- default color space, DPI, etc.
+- **Logo exclusion rule** -- logos are NEVER mentioned in prompts (model generates artifacts). Described as "clean negative space" instead; logos composited in presentation software
+- Presentation mode modifier library in prompt-engineering.md (background styles, layout zones, typography, pattern overlays, slide types)
+- 4 Presentation prompt templates (2 Complete, 2 Background-Only)
+- Brand Style Guide Integration section in prompt-engineering.md
+- Expanded merge rules (items 6-12) for brand guide fields in presets.md
+- 8 new CLI args in presets.py for brand guide creation
+- README updated with new feature documentation, rationale, and upstream tracking
+
+### Changed
+- Domain modes expanded from 9 to 11 (Presentation Complete + Background)
+- presets.py `create` command accepts brand guide fields (backward-compatible)
+- Logo handling rewritten: replaced "reserve space for logo" with negative-space approach
+
 ## [1.4.2] - 2026-03-27
 
 ### Added
@@ -149,6 +176,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Batch variations, multi-turn chat, prompt inspiration
 - Install script with validation
 
+[1.5.0]: https://github.com/juliandickie/banana-claude/releases/tag/v1.5.0
 [1.4.2]: https://github.com/AgriciDaniel/banana-claude/releases/tag/v1.4.2
 [1.4.1]: https://github.com/AgriciDaniel/banana-claude/releases/tag/v1.4.1
 [1.4.0]: https://github.com/AgriciDaniel/banana-claude/releases/tag/v1.4.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,7 +10,7 @@ authors:
 repository-code: "https://github.com/AgriciDaniel/banana-claude"
 url: "https://www.skool.com/ai-marketing-hub-pro"
 license: MIT
-version: "1.4.1"
+version: "1.4.2"
 date-released: "2026-03-27"
 keywords:
   - ai-image-generation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,18 +38,23 @@ This repo follows the official Claude Code plugin layout:
 | File | Purpose |
 |---|---|
 | `skills/banana/SKILL.md` | Main orchestrator. Edit to change Claude's behavior. |
-| `skills/banana/references/gemini-models.md` | Model roster, routing table, resolution defaults. Update when Google releases new models. |
-| `skills/banana/references/prompt-engineering.md` | The prompt construction system. Update when Google publishes new guidance. |
-| `skills/banana/references/mcp-tools.md` | API parameter reference. Update when Google changes the API. |
-| `skills/banana/scripts/generate.py` | Direct API fallback for generation. Uses urllib.request (stdlib). |
-| `skills/banana/scripts/edit.py` | Direct API fallback for editing. Uses urllib.request (stdlib). |
+| `skills/banana/references/gemini-models.md` | Model roster, routing table, resolution tables, input limits. Update when Google releases new models. |
+| `skills/banana/references/prompt-engineering.md` | The prompt construction system: 5-component formula, 11 domain modes, PEEL strategy, brand guide integration. Update when Google publishes new guidance. |
+| `skills/banana/references/mcp-tools.md` | MCP tool parameter reference. Update when Google changes the API. |
+| `skills/banana/references/replicate.md` | Replicate backend API reference (`google/nano-banana-2`). |
+| `skills/banana/references/presets.md` | Brand Style Guide schema (17 fields, 8 optional for brand guides). |
+| `skills/banana/scripts/generate.py` | Direct Gemini API fallback for generation. Uses urllib.request (stdlib). |
+| `skills/banana/scripts/edit.py` | Direct Gemini API fallback for editing. Uses urllib.request (stdlib). |
+| `skills/banana/scripts/replicate_generate.py` | Replicate API fallback for generation. Uses urllib.request (stdlib). |
+| `skills/banana/scripts/replicate_edit.py` | Replicate API fallback for editing. Uses urllib.request (stdlib). |
+| `skills/banana/scripts/presets.py` | Brand Style Guide CRUD (list, show, create, delete). |
 | `agents/brief-constructor.md` | Subagent for prompt construction. |
 
 ## Scripts use stdlib only
 
-The fallback scripts (`generate.py`, `edit.py`) use Python's `urllib.request`
-to call the Gemini REST API directly. They have ZERO pip dependencies by design.
-Do NOT add `google-genai` or `requests` as dependencies -- the stdlib approach
+All fallback scripts (`generate.py`, `edit.py`, `replicate_generate.py`, `replicate_edit.py`)
+use Python's `urllib.request` to call APIs directly. They have ZERO pip dependencies by design.
+Do NOT add `google-genai`, `requests`, or `replicate` as dependencies -- the stdlib approach
 ensures the skill works on any system with Python 3.6+.
 
 ## Key constraints
@@ -59,28 +64,27 @@ ensures the skill works on any system with Python 3.6+.
 - No negative prompt parameter exists. Use semantic reframing in the prompt.
 - `responseModalities` must explicitly include "IMAGE" or the API returns text only.
 - NEVER use banned keywords in prompts: "8K", "masterpiece", "ultra-realistic", "high resolution" -- these degrade output quality. Use prestigious context anchors instead (see prompt-engineering.md).
+- NEVER mention "logo" in Presentation mode prompts -- the model generates unwanted logo artifacts. Describe the area as "clean negative space" instead. Logos are composited in presentation software.
+- Brand Style Guide fields in presets are optional -- old presets without them continue to work.
+- Fallback chain: MCP (primary) -> Direct Gemini API -> Replicate.
 
-## Distribution
+## Upstream tracking
 
-### Plugin marketplace (primary)
+This is a fork of https://github.com/AgriciDaniel/banana-claude (v1.4.1 baseline).
 
-Users install via:
-```shell
-/plugin marketplace add AgriciDaniel/banana-claude
-/plugin install banana-claude@banana-claude-marketplace
+To check for upstream changes:
+```bash
+git fetch upstream
+git diff upstream/main
 ```
 
-### Official Anthropic marketplace
+Our additions over upstream: Replicate backend, Presentation mode, Brand Style Guides,
+research-driven prompt improvements (5-Input Creative Brief, PEEL strategy, Edit-First,
+Progressive Enhancement, expanded character consistency, multilingual support).
 
-Submission pending via [claude.ai/settings/plugins/submit](https://claude.ai/settings/plugins/submit).
-Once accepted, users install with:
-```shell
-/plugin install banana-claude@claude-plugins-official
-```
+## Installation
 
-### Standalone install (legacy)
-
-Still supported via `install.sh` for users not on the plugin system.
+Test locally: `claude --plugin-dir .` or standalone: `bash install.sh`
 
 ## Versioning
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ AI image generation skill for Claude Code where **Claude acts as Creative Direct
 Unlike simple API wrappers, Claude interprets your intent, selects domain expertise, constructs optimized prompts using Google's official 5-component formula, and orchestrates Gemini for the best possible results.
 
 [![Claude Code Skill](https://img.shields.io/badge/Claude%20Code-Skill-blue)](https://claude.ai/claude-code)
-[![Version](https://img.shields.io/badge/version-1.4.1-coral)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.4.2-coral)](CHANGELOG.md)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 <details>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-<!-- Updated: 2026-03-19v2 -->
+<!-- Updated: 2026-04-06 -->
+<!-- Forked from: https://github.com/AgriciDaniel/banana-claude -->
 
 ![Banana Claude](screenshots/cover-image.webp)
 
@@ -9,12 +10,14 @@ AI image generation skill for Claude Code where **Claude acts as Creative Direct
 Unlike simple API wrappers, Claude interprets your intent, selects domain expertise, constructs optimized prompts using Google's official 5-component formula, and orchestrates Gemini for the best possible results.
 
 [![Claude Code Skill](https://img.shields.io/badge/Claude%20Code-Skill-blue)](https://claude.ai/claude-code)
-[![Version](https://img.shields.io/badge/version-1.4.2-coral)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.5.0-coral)](CHANGELOG.md)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Upstream](https://img.shields.io/badge/upstream-AgriciDaniel%2Fbanana--claude-gray)](https://github.com/AgriciDaniel/banana-claude)
 
 <details>
 <summary>Table of Contents</summary>
 
+- [What's New in This Fork](#whats-new-in-this-fork)
 - [Installation](#installation)
 - [Quick Start](#quick-start)
 - [Commands](#commands)
@@ -22,14 +25,53 @@ Unlike simple API wrappers, Claude interprets your intent, selects domain expert
 - [What Makes This Different](#what-makes-this-different)
 - [The 5-Component Prompt Formula](#the-5-component-prompt-formula)
 - [Domain Modes](#domain-modes)
+- [Presentation Mode](#presentation-mode)
+- [Brand Style Guides](#brand-style-guides)
+- [Replicate Backend](#replicate-backend)
 - [Models](#models)
 - [Architecture](#architecture)
 - [Requirements](#requirements)
+- [Upstream Tracking](#upstream-tracking)
 - [Changelog](CHANGELOG.md)
-- [Contributing](#contributing)
 - [License](#license)
 
 </details>
+
+## What's New in This Fork
+
+This fork extends [AgriciDaniel/banana-claude](https://github.com/AgriciDaniel/banana-claude) with features driven by production use and research analysis of Google's prompting guidance:
+
+### Presentation Mode (v1.5.0)
+Two generation options for slide visuals:
+- **Complete Slide** -- Nano Banana 2 renders headline and body text directly in the image, producing finished slides
+- **Background Only** -- Clean backgrounds with intentional negative space, designed for layering text and logos in Keynote/PowerPoint/Google Slides
+
+Logos are never mentioned in prompts (the model generates unwanted artifacts). Instead, logo areas are described as "clean negative space" and logos are composited in presentation software.
+
+### Brand Style Guides (v1.5.0)
+Enhanced preset system with 8 new optional fields for project-wide visual consistency:
+- `background_styles` -- Named background variants (dark-premium, gradient, split-layout)
+- `visual_motifs` -- Pattern overlays with opacity (e.g., "geometric network at 30%")
+- `prompt_suffix` -- Appended verbatim to every prompt for brand consistency
+- `prompt_keywords` -- Categorized keywords woven naturally into prompts
+- `do_list` / `dont_list` -- Brand guardrails checked before generation
+- `logo_placement` -- Records where logos go in post-production (not in prompts)
+- `technical_specs` -- Default color space, DPI, and other technical standards
+
+Fully backward-compatible -- existing simple presets continue to work unchanged.
+
+### Replicate Backend (v1.4.2)
+`google/nano-banana-2` on Replicate as an alternative API backend. Fallback chain: MCP (primary) -> Direct Gemini API -> Replicate. Includes `replicate_generate.py` and `replicate_edit.py` (stdlib-only, zero pip deps).
+
+### Research-Driven Improvements (v1.4.2)
+Based on analysis of Google's official prompting guides and two research documents:
+- **5-Input Creative Brief** -- Purpose, Audience, Subject, Brand, References
+- **"Start with Intent, Refine with Specs"** -- Two-phase prompting with PEEL strategy (Position, Expression, Environment, Lens)
+- **Edit-First Principle** -- 90% of refinements should edit, not regenerate
+- **Progressive Enhancement** -- 4-phase workflow for multi-turn chat sessions
+- **Expanded character consistency** -- Identity-locked patterns, group photos (up to 5 people), sequential storytelling
+- **Multilingual support** -- Translation within images, cultural adaptation
+- **Official spec corrections** -- Output tokens (2,520 not 1,290), HEIC/HEIF input, resolution pixel tables
 
 ## Installation
 
@@ -94,7 +136,7 @@ claude
 /banana inspire
 ```
 
-Claude will ask about your brand, select the right domain mode (Cinema, Product, Portrait, Editorial, UI, Logo, Landscape, Infographic, Abstract), construct a detailed prompt with lighting and composition, set the right aspect ratio, and generate.
+Claude will ask about your brand, select the right domain mode (Cinema, Product, Portrait, Editorial, UI, Logo, Landscape, Infographic, Abstract, Presentation), construct a detailed prompt with lighting and composition, set the right aspect ratio, and generate.
 
 ![Banana Claude in action](screenshots/banana-claude-skillcommand.gif)
 
@@ -109,6 +151,7 @@ Claude will ask about your brand, select the right domain mode (Cinema, Product,
 | `/banana inspire [category]` | Browse 2,500+ prompt database |
 | `/banana batch <idea> [N]` | Generate N variations (default: 3) |
 | `/banana setup` | Configure MCP and API key |
+| `/banana setup replicate` | Configure Replicate API token (alternative backend) |
 | `/banana preset [list\|create\|show\|delete]` | Manage brand/style presets |
 | `/banana cost [summary\|today\|estimate]` | View cost tracking and estimates |
 
@@ -118,15 +161,20 @@ Claude will ask about your brand, select the right domain mode (Cinema, Product,
 
 ## What Makes This Different
 
-- **Intent Analysis** -- Understands *what you actually need* (blog header? app icon? product shot?)
-- **Domain Expertise** -- Selects the right creative lens (Cinema, Product, Portrait, Editorial, UI, Logo, Landscape, Infographic, Abstract)
+- **5-Input Creative Brief** -- Gathers Purpose, Audience, Subject, Brand, and References before generating
+- **Domain Expertise** -- Selects the right creative lens (Cinema, Product, Portrait, Editorial, UI, Logo, Landscape, Infographic, Abstract, Presentation)
 - **5-Component Prompt Formula** -- Constructs prompts with Subject + Action + Location/Context + Composition + Style (includes lighting)
+- **Start with Intent, Refine with Specs** -- Two-phase prompting using the PEEL strategy for iterative refinement
+- **Edit-First Workflow** -- 90% of refinements edit the image rather than regenerating from scratch
+- **Brand Style Guides** -- Rich preset system with background styles, motifs, keywords, do's/don'ts, and prompt suffixes
+- **Presentation Mode** -- Two options: complete slides with rendered text, or clean backgrounds for layering
 - **Prompt Adaptation** -- Translates patterns from a 2,500+ curated prompt database to Gemini's natural language format
 - **Post-Processing** -- Crops, removes backgrounds, converts formats, resizes for platforms
-- **Batch Variations** -- Generates N variations rotating different components
-- **Session Consistency** -- Maintains character/style across multi-turn conversations
+- **Batch Variations** -- Generates N variations with Literal/Creative/Premium prompt styles
+- **Session Consistency** -- Maintains character/style across multi-turn conversations with progressive enhancement
+- **Triple Fallback** -- MCP -> Direct Gemini API -> Replicate for maximum availability
 - **4K Resolution Output** -- Up to 4096×4096 with `imageSize` control
-- **14 Aspect Ratios** -- Including ultra-wide 21:9 for cinematic compositions
+- **14 Aspect Ratios** -- Including ultra-wide 21:9 and extreme 8:1 for banners
 
 ## The 5-Component Prompt Formula
 
@@ -161,6 +209,55 @@ Instead of sending "a cat in space" to Gemini, Claude constructs:
 | **Landscape** | Backgrounds, wallpapers | "A misty mountain sunrise for my desktop" |
 | **Infographic** | Data, diagrams | "Visualize our Q1 sales growth" |
 | **Abstract** | Generative art, textures | "Voronoi tessellation in neon gradients" |
+| **Presentation (Complete)** | Finished slides with text | "Title slide with 'DIGITAL INNOVATION' headline" |
+| **Presentation (Background)** | Slide backgrounds for layering | "Dark premium background for keynote deck" |
+
+## Presentation Mode
+
+Presentation mode has two generation options designed for real-world slide workflows:
+
+**Complete Slide** -- The model renders headline and body text directly in the image. Nano Banana 2's text rendering (94% accuracy under 25 characters) produces finished slides ready to use as-is. Best for title slides, quote slides, and simple content layouts.
+
+**Background Only** -- Produces clean backgrounds with intentional negative space where text and logos will be added in Keynote, PowerPoint, or Google Slides. The prompt explicitly states "NO text, NO logos, NO labels" to prevent the model from generating unwanted artifacts.
+
+> **Why no logos in prompts?** Gemini interprets every word literally. "Reserve space for logo" becomes "generate a logo here." The correct approach is describing the area as "clean negative space" or "simple uncluttered background," then compositing the logo as a separate layer in your presentation software where you have pixel-perfect control.
+
+## Brand Style Guides
+
+Enhanced presets for project-wide visual consistency. Create a brand style guide once, and every generated image inherits the brand's visual language:
+
+```bash
+# Create a brand style guide
+/banana preset create premium-brand \
+  --colors "#000000,#FFC000,#FFFFFF" \
+  --style "premium dark photography, dramatic lighting, gold accents" \
+  --mood "confident, innovative, premium" \
+  --visual-motifs "geometric network pattern in silver at 30% opacity" \
+  --prompt-suffix "Premium dark aesthetic with gold accents, dramatic lighting." \
+  --do-list "Use negative space,High contrast,Keep patterns subtle" \
+  --dont-list "No busy backgrounds,No more than 2 accent colors"
+
+# Use it
+/banana generate "title slide for digital innovation keynote"
+# Claude automatically loads the brand guide and applies it
+```
+
+Brand Style Guide fields are all optional -- simple presets (just colors + style) continue to work exactly as before.
+
+## Replicate Backend
+
+An alternative API backend using `google/nano-banana-2` on Replicate. Useful when:
+- MCP server is unavailable or not configured
+- You prefer simpler auth (Replicate token vs. Google Cloud setup)
+- You need webhook/async processing
+
+```bash
+# Configure Replicate
+/banana setup replicate
+
+# The fallback chain handles the rest automatically:
+# 1. MCP (primary) -> 2. Direct Gemini API -> 3. Replicate
+```
 
 ## Models
 
@@ -177,21 +274,24 @@ banana-claude/                         # Claude Code Plugin
 │   ├── plugin.json                    # Plugin manifest
 │   └── marketplace.json               # Marketplace catalog
 ├── skills/banana/                     # Main skill
-│   ├── SKILL.md                       # Creative Director orchestration (v1.4)
+│   ├── SKILL.md                       # Creative Director orchestration (v1.5)
 │   ├── references/
-│   │   ├── prompt-engineering.md      # 5-component formula, banned keywords, safety rephrase
-│   │   ├── gemini-models.md           # Model specs, rate limits, capabilities
+│   │   ├── prompt-engineering.md      # 5-component formula, domain modes, PEEL strategy
+│   │   ├── gemini-models.md           # Model specs, resolution tables, input limits
 │   │   ├── mcp-tools.md              # MCP tool parameters and responses
+│   │   ├── replicate.md              # Replicate backend API reference
 │   │   ├── post-processing.md        # ImageMagick/FFmpeg pipelines, green screen
 │   │   ├── cost-tracking.md          # Pricing table, usage guide
-│   │   └── presets.md                # Brand preset schema and examples
+│   │   └── presets.md                # Brand Style Guide schema and examples
 │   └── scripts/
-│       ├── setup_mcp.py              # Configure MCP in Claude Code
+│       ├── setup_mcp.py              # Configure MCP + Replicate
 │       ├── validate_setup.py         # Verify installation
-│       ├── generate.py               # Direct API fallback -- generation
-│       ├── edit.py                   # Direct API fallback -- editing
+│       ├── generate.py               # Direct Gemini API fallback -- generation
+│       ├── edit.py                   # Direct Gemini API fallback -- editing
+│       ├── replicate_generate.py     # Replicate API fallback -- generation
+│       ├── replicate_edit.py         # Replicate API fallback -- editing
 │       ├── cost_tracker.py           # Cost logging and summaries
-│       ├── presets.py                # Brand/style preset management
+│       ├── presets.py                # Brand Style Guide management
 │       └── batch.py                  # CSV batch workflow parser
 └── agents/
     └── brief-constructor.md           # Subagent for prompt construction
@@ -218,9 +318,15 @@ banana-claude/                         # Claude Code Plugin
 bash banana-claude/install.sh --uninstall
 ```
 
-## Contributing
+## Upstream Tracking
 
-Contributions welcome! Please open an issue or submit a pull request.
+This fork extends [AgriciDaniel/banana-claude](https://github.com/AgriciDaniel/banana-claude). To check for upstream changes:
+
+```bash
+git fetch upstream
+git diff upstream/main   # see what changed
+git merge upstream/main  # integrate selectively
+```
 
 ## License
 
@@ -228,4 +334,4 @@ MIT License -- see [LICENSE](LICENSE) for details.
 
 ---
 
-Built for Claude Code by [@AgriciDaniel](https://github.com/AgriciDaniel)
+Originally built for Claude Code by [@AgriciDaniel](https://github.com/AgriciDaniel). Extended with Replicate backend, Presentation mode, Brand Style Guides, and research-driven prompt improvements.

--- a/skills/banana/SKILL.md
+++ b/skills/banana/SKILL.md
@@ -109,6 +109,21 @@ python3 ${CLAUDE_SKILL_DIR}/scripts/presets.py list
 If a matching preset exists, load it with `presets.py show NAME` and use its values
 as defaults for the Reasoning Brief. User instructions override preset values.
 
+**Brand Style Guide fields** (when present in the preset):
+- Apply `visual_motifs` to the Style component (append motif at specified opacity)
+- If in Presentation mode, select from `background_styles` based on slide type
+- Append `prompt_suffix` verbatim to the end of every constructed prompt
+- Check the final prompt against `do_list` and `dont_list` rules
+- Weave `prompt_keywords` naturally into the prompt (not as a raw list)
+- Use `technical_specs` for default ratio/resolution if not overridden by user
+
+**Logo handling -- IMPORTANT:**
+Do NOT mention "logo," "logo placement," or "reserve space for logo" in any prompt.
+Gemini interprets logo references as instructions to generate a logo, which produces
+unwanted artifacts. Instead, describe the area as "clean negative space," "simple
+uncluttered background," or "generous white space in the lower-left corner." Logos
+are added as separate layers in Keynote/PowerPoint/Google Slides after generation.
+
 ### Step 2: Select Domain Mode
 
 Choose the expertise lens that best fits the request:
@@ -124,6 +139,8 @@ Choose the expertise lens that best fits the request:
 | **Landscape** | Environments, backgrounds, wallpapers | Atmospheric perspective, depth layers, time of day |
 | **Abstract** | Patterns, textures, generative art | Color theory, mathematical forms, movement |
 | **Infographic** | Data visualization, diagrams, charts | Layout structure, text rendering, hierarchy |
+| **Presentation (Complete)** | Full slide with text rendered in the image | Background + headline/body text rendered by the model, ready to use as-is |
+| **Presentation (Background)** | Slide backgrounds for layering in Keynote/PPT/Slides | Clean backgrounds with negative space for text/logo overlay -- NO text, NO logos in the image |
 
 ### Step 3: Construct the Reasoning Brief
 
@@ -211,6 +228,7 @@ Match ratio to use case -- call `set_aspect_ratio` BEFORE generating:
 | Large format photography | `5:4` | Landscape fine art |
 | Website banner | `4:1` or `8:1` | Ultra-wide strip |
 | Ultrawide / cinematic | `21:9` | Film-grade (3.1 Flash only) |
+| Presentation slide / deck | `16:9` | Widescreen standard for slides |
 
 ### Step 4.5: Select Resolution (optional)
 
@@ -224,6 +242,8 @@ Choose output resolution based on intended use:
 | `4K` | Print production, hero images, final deliverables |
 
 Note: Resolution control (`imageSize`) depends on MCP package version support.
+
+Presentation mode defaults to `4K` for slide backgrounds (3840x2160), `2K` for composited slides.
 
 ### Step 5: Call the MCP
 

--- a/skills/banana/SKILL.md
+++ b/skills/banana/SKILL.md
@@ -3,7 +3,7 @@ name: banana
 description: "AI image generation Creative Director powered by Google Gemini Nano Banana models. Use this skill for ANY request involving image creation, editing, visual asset production, or creative direction. Triggers on: generate an image, create a photo, edit this picture, design a logo, make a banner, visual for my anything, and all /banana commands. Handles text-to-image, image editing, multi-turn creative sessions, batch workflows, and brand presets."
 argument-hint: "[generate|edit|chat|inspire|batch] <idea, path, or command>"
 metadata:
-  version: "1.4.1"
+  version: "1.4.2"
   author: AgriciDaniel
   mcp-package: "@ycse/nanobanana-mcp"
 ---
@@ -34,13 +34,30 @@ construct an optimized prompt using the 5-Component Formula from `references/pro
 | `/banana chat` | Multi-turn visual session (character/style consistent) |
 | `/banana inspire [category]` | Browse prompt database for ideas |
 | `/banana batch <idea> [N]` | Generate N variations (default: 3) |
-| `/banana setup` | Install MCP server and configure API key |
+| `/banana setup` | Install MCP server and configure Google AI API key |
+| `/banana setup replicate` | Configure Replicate API token (alternative backend) |
 | `/banana preset [list\|create\|show\|delete]` | Manage brand/style presets |
 | `/banana cost [summary\|today\|estimate]` | View cost tracking and estimates |
 
 ## Core Principle: Claude as Creative Director
 
 **NEVER** pass the user's raw text as-is to `gemini_generate_image`.
+
+### Core Principle #2: Edit First, Regenerate Last
+
+**90% of refinements should use editing, not regeneration.**
+
+When an image is 70-90% correct, use `gemini_edit_image` or `gemini_chat` to refine it.
+Only regenerate from scratch when the composition or concept is fundamentally wrong.
+
+| Scenario | Action | Why |
+|----------|--------|-----|
+| Subject and angle correct, minor tweaks needed | **EDIT** | Preserves what works, faster, cheaper |
+| Exact pose/layout must be maintained | **EDIT** | Can't recreate exact composition |
+| Color, lighting, or mood needs adjustment | **EDIT** | Targeted changes preserve structure |
+| Composition fundamentally wrong | **REGENERATE** | Easier than fixing broken layout |
+| Style completely mismatched | **REGENERATE** | Faster than iterating from wrong base |
+| Core concept is off | **REGENERATE** | Start fresh with corrected brief |
 
 Follow this pipeline for every generation -- no exceptions:
 
@@ -58,16 +75,30 @@ Follow this pipeline for every generation -- no exceptions:
 8. On success: save image, log cost, return file path and summary
 9. Never report success until a valid image file path is confirmed to exist
 
-### Step 1: Analyze Intent
+### Step 1: Analyze Intent (5-Input Creative Brief)
 
-Determine what the user actually needs:
-- What is the final use case? (blog, social, app, print, presentation)
+Gather these 5 inputs to build a complete creative brief. For simple requests,
+infer what you can. For vague requests, ASK clarifying questions.
+
+| # | Input | Question | Examples |
+|---|-------|----------|----------|
+| 1 | **Purpose** | Where will this be used? | Blog hero, YouTube thumb, e-commerce, Instagram ad, print poster |
+| 2 | **Audience** | Who is it for? | Gen Z creators, luxury buyers, busy parents, enterprise B2B |
+| 3 | **Subject** | What is the literal content? | "Matte black ceramic mug, 12oz, minimalist" — not "cool mug" |
+| 4 | **Brand Guidelines** | What vibe/feeling? | Warm + premium, bold + energetic, calm + minimal |
+| 5 | **References** | Any visual examples? | Upload images for style, texture, or composition matching |
+
+**Why this matters:** A coffee mug for e-commerce gets centered, clean lighting.
+The same mug for a homepage hero gets softer lighting, more negative space, wider
+composition. Purpose and Audience change everything.
+
+Also determine:
 - What style fits? (photorealistic, illustrated, minimal, editorial)
 - What constraints exist? (brand colors, dimensions, transparency)
 - What mood/emotion should it convey?
 
 If the request is vague (e.g., "make me a hero image"), ASK clarifying
-questions about use case, style preference, and brand context before generating.
+questions about purpose, audience, and brand context before generating.
 
 ### Step 1.5: Check for Presets
 
@@ -144,6 +175,24 @@ context and supporting elements].
 ```
 
 For more templates see `references/prompt-engineering.md` → Proven Prompt Templates.
+
+### Step 3.5: Prompt Variations (Optional)
+
+For exploratory requests or `/banana batch`, offer the user 3 prompt variations
+built from the same creative brief:
+
+| Variation | Style | Best For |
+|-----------|-------|----------|
+| **Literal** | Clean, accurate, faithful to brief | E-commerce, product pages, documentation |
+| **Creative** | Looser interpretation, mood/storytelling emphasis | Social media, blog headers, editorial |
+| **Premium** | Polished, editorial, prestigious context anchors | Ads, hero images, print, campaigns |
+
+**When to offer variations:**
+- User says "show me options" or "give me choices"
+- `/banana batch` command
+- Exploratory/brainstorming sessions
+
+**When to skip:** Simple, specific requests with clear intent → generate one optimized prompt.
 
 ### Step 4: Select Aspect Ratio
 
@@ -306,7 +355,8 @@ Default: `gemini-3.1-flash-image-preview`. Switch with `set_model` when routing 
 | `IMAGE_SAFETY` | Output blocked -- analyze prompt for triggers, suggest 2-3 rephrased alternatives. See `references/prompt-engineering.md` Safety Rephrase section. Do NOT auto-retry without user approval. |
 | `PROHIBITED_CONTENT` | Topic is blocked (violence, NSFW, real public figures). Non-retryable -- explain why and suggest alternative concepts. |
 | Safety filter false positive | Filters are overly cautious. Rephrase using abstraction, artistic framing, or metaphor. Common: "dog" blocked → try "a friendly golden retriever in a sunny park". See `references/prompt-engineering.md` Safety Rephrase Strategies. |
-| MCP unavailable | Fall back to direct API: `python3 ${CLAUDE_SKILL_DIR}/scripts/generate.py --prompt "..." --aspect-ratio "16:9"` or `python3 ${CLAUDE_SKILL_DIR}/scripts/edit.py --image PATH --prompt "..."`. These call the Gemini REST API directly with no MCP dependency. |
+| MCP unavailable | Fall back in this order: **1)** Direct Gemini API (if `GOOGLE_AI_API_KEY` is set): `python3 ${CLAUDE_SKILL_DIR}/scripts/generate.py --prompt "..."` **2)** Replicate API (if `REPLICATE_API_TOKEN` is set): `python3 ${CLAUDE_SKILL_DIR}/scripts/replicate_generate.py --prompt "..."`. For editing: use `edit.py` or `replicate_edit.py` respectively. |
+| Replicate at capacity | Replicate may throttle during peak usage. Retry after 30s, or fall back to direct Gemini API. |
 | Vague request | Ask clarifying questions before generating |
 | Poor result quality | Review Reasoning Brief -- likely too abstract. Load `references/prompt-engineering.md` Proven Templates and rebuild with specifics. |
 
@@ -325,6 +375,13 @@ After generating, always provide:
 2. **The crafted prompt** -- show the user what you sent (educational)
 3. **Settings used** -- model, aspect ratio
 4. **Suggestions** -- 1-2 refinement ideas if relevant
+5. **Quality check** (internal -- verify before presenting):
+   - [ ] Resolution matches intended use case
+   - [ ] No visible artifacts or distortions
+   - [ ] All requested elements present in the image
+   - [ ] Text is legible (if applicable, under 25 chars)
+   - [ ] Lighting and mood match the creative brief
+   - [ ] Brand guidelines satisfied (if preset or guidelines provided)
 
 ## Reference Documentation
 
@@ -332,14 +389,22 @@ Load on-demand -- do NOT load all at startup:
 - `references/prompt-engineering.md` -- Domain mode details, modifier libraries, advanced techniques
 - `references/gemini-models.md` -- Model specs, rate limits, capabilities
 - `references/mcp-tools.md` -- MCP tool parameters and response formats
+- `references/replicate.md` -- Replicate backend API reference and CLI usage
 - `references/post-processing.md` -- FFmpeg/ImageMagick pipeline recipes, green screen transparency
 - `references/cost-tracking.md` -- Pricing table, usage guide, free tier limits
 - `references/presets.md` -- Brand preset schema, examples, merge behavior
 
 ## Setup
 
+**MCP Server (primary):**
 Run `python3 scripts/setup_mcp.py` to configure the MCP server. Requires:
 - Node.js 18+ (npx)
 - Google AI API key (free at https://aistudio.google.com/apikey)
+
+**Replicate Backend (alternative):**
+Run `python3 scripts/setup_mcp.py --replicate-key YOUR_TOKEN` to configure Replicate.
+- Get a token at https://replicate.com/account/api-tokens
+- No Google Cloud setup needed -- simpler auth
+- Verify: `python3 scripts/setup_mcp.py --check-replicate`
 
 Verify: `python3 scripts/validate_setup.py`

--- a/skills/banana/references/cost-tracking.md
+++ b/skills/banana/references/cost-tracking.md
@@ -13,6 +13,7 @@
 | 2.5 Flash | 512 | $0.020 | Draft fallback |
 | 2.5 Flash | 1K | $0.039 | Standard fallback |
 | Batch API | Any | 50% of above | Asynchronous, higher latency |
+| Replicate (`google/nano-banana-2`) | Any | ~$0.05 est. | Per-second compute, check replicate.com/pricing |
 
 Pricing is approximate, based on ~1,290 output tokens per image.
 Research suggests actual costs may be ~$0.067/img. Verify at https://ai.google.dev/gemini-api/docs/pricing
@@ -22,6 +23,7 @@ Research suggests actual costs may be ~$0.067/img. Verify at https://ai.google.d
 - ~10 requests per minute (RPM)
 - ~500 requests per day (RPD)
 - Per Google Cloud project, resets midnight Pacific
+- Note: Replicate does NOT have a free tier; all usage is billed per-second compute
 
 ## Cost Tracker Commands
 

--- a/skills/banana/references/gemini-models.md
+++ b/skills/banana/references/gemini-models.md
@@ -15,9 +15,9 @@
 | **Aspect Ratios** | All 14 ratios including extreme: 1:4, 4:1, 1:8, 8:1 (see table below) |
 | **Max Resolution** | Up to 4096×4096 (4K tier) |
 | **Input Tokens** | 131,072 |
-| **Features** | Google Search grounding (web + image), thinking levels, image-only output, extreme aspect ratios |
+| **Features** | Google Search grounding (web + image), thinking levels, image-only output, extreme aspect ratios, HEIC/HEIF input support |
 | **Rate Limits (Free)** | ~5-15 RPM / ~20-500 RPD (per project, resets midnight Pacific. Cut ~92% Dec 2025) |
-| **Output Tokens** | ~1,290 output tokens per image |
+| **Output Tokens** | Up to ~2,520 output tokens per image |
 | **Best For** | All standard production generation and editing -- most use cases |
 
 ### gemini-2.5-flash-image -- Nano Banana (Original)
@@ -93,6 +93,10 @@ All 14 supported ratios. Availability varies by model:
 | `1:8` | Extreme tall | Narrow vertical strips | ✅ | ❌ |
 | `8:1` | Extreme wide | Ultra-wide banners | ✅ | ❌ |
 
+> **Note:** `1:4` and `1:8` are community-reported but NOT listed in Google's official
+> documentation (March 2026). Use `4:1` and `8:1` (which are officially documented)
+> for wide strips. The tall variants may work in practice but are not guaranteed.
+
 ## Resolution Tiers
 
 Control output resolution with the `imageSize` parameter. Note the **UPPERCASE** requirement -- lowercase values are silently rejected.
@@ -109,6 +113,41 @@ Control output resolution with the `imageSize` parameter. Note the **UPPERCASE**
 - Higher resolutions consume more tokens and cost more
 - The API default is `1K` if `imageSize` is omitted. The banana skill defaults to `2K` -- always pass `imageSize` explicitly
 - `imageSize` value MUST be uppercase -- `"2k"` will be silently ignored
+
+### Resolution by Aspect Ratio (Pixel Dimensions)
+
+Exact output dimensions for each aspect ratio at each resolution tier:
+
+| Ratio | 512 | 1K | 2K | 4K |
+|-------|-----|----|----|-----|
+| 1:1 | 512×512 | 1024×1024 | 2048×2048 | 4096×4096 |
+| 16:9 | — | 1376×768 | 2752×1536 | 5504×3072 |
+| 9:16 | — | 768×1376 | 1536×2752 | 3072×5504 |
+| 4:3 | — | 1152×864 | 2304×1728 | 4608×3456 |
+| 3:4 | — | 864×1152 | 1728×2304 | 3456×4608 |
+| 3:2 | — | 1152×768 | 2304×1536 | 4608×3072 |
+| 2:3 | — | 768×1152 | 1536×2304 | 3072×4608 |
+| 4:5 | — | 928×1152 | 1856×2304 | 3712×4608 |
+| 5:4 | — | 1152×928 | 2304×1856 | 4608×3712 |
+| 21:9 | — | 1536×656 | 3072×1312 | 6144×2624 |
+| 4:1 | — | 2048×512 | 4096×1024 | — |
+| 8:1 | — | 2048×256 | 4096×512 | — |
+
+"—" = not available at that resolution tier or ratio.
+
+## Input Limits
+
+| Limit | Value | Notes |
+|-------|-------|-------|
+| Max images per prompt | 14 | 10 object refs + 4 character refs |
+| Max image size (inline) | 7 MB | Direct upload / console |
+| Max image size (GCS) | 30 MB | Via Google Cloud Storage URI |
+| Total request size | 500 MB | All inputs combined |
+| Supported image formats | JPEG, PNG, WebP, HEIC, HEIF | |
+| Max people (high-fidelity) | 5 | For reliable character consistency |
+| Max objects (high-fidelity) | 6 | For reliable object preservation |
+| Recommended prompt length | 100–300 words | Diminishing returns past ~300 words |
+| Max input tokens | 131,072 | Full context window |
 
 ## API Configuration
 
@@ -154,6 +193,30 @@ Control how much the model "thinks" before generating. Higher levels improve com
 ```
 Levels: `minimal`, `low`, `medium`, `high`
 
+### Thinking Visibility
+
+Enable thought visibility to see the model's reasoning process:
+```json
+{
+  "generationConfig": {
+    "thinkingConfig": {
+      "includeThoughts": true
+    }
+  }
+}
+```
+
+When enabled, the response includes interim "thought" parts:
+- **Thought text** -- the model's reasoning about composition, style, and approach
+- **Thought images** -- interim draft images the model generates while refining (not charged)
+- Only the final image is the deliverable; thought images show the refinement process
+
+**When thinking helps most:**
+- Complex multi-element compositions (5+ elements to arrange)
+- Mathematical or scientific visualizations
+- Architectural/spatial problems
+- Any prompt requiring logical reasoning about layout
+
 ### Google Search Grounding
 Ground generation in real-world visual references. Supports web and image search (Nano Banana 2):
 ```json
@@ -190,8 +253,9 @@ Useful for character consistency, style transfer, and brand-aligned generation.
 | NB2 (3.1 Flash) | 4K | ~$0.268 | 4x standard |
 | NB (2.5 Flash) | 1K | ~$0.039 | Previous gen, budget option |
 | Batch API | Any | 50% discount | Asynchronous, higher latency |
+| Replicate (`google/nano-banana-2`) | Any | ~$0.05 est. | Alternative backend, simpler auth |
 
-Pricing is approximate and based on ~1,290 output tokens per image.
+Pricing is approximate and based on up to ~2,520 output tokens per image.
 
 ## Image Output Specs
 
@@ -224,6 +288,19 @@ Gemini uses a two-layer safety architecture:
 
 - **SynthID watermarks** are always embedded in generated images (invisible, machine-readable)
 - **C2PA metadata** is included on paid outputs (verifiable provenance chain)
+
+## Watermark Behavior by Tier
+
+| Tier | SynthID (invisible) | Visible Watermark | C2PA Metadata |
+|------|:-------------------:|:-----------------:|:-------------:|
+| Free | ✅ | ✅ Gemini sparkle | ❌ |
+| Google AI Pro ($20/mo) | ✅ | ✅ Gemini sparkle | ❌ |
+| Google AI Ultra | ✅ | ❌ None | ✅ |
+| AI Studio (API) | ✅ | ❌ None | ✅ |
+| Vertex AI | ✅ | ❌ None | ✅ |
+
+**SynthID** is always embedded -- invisible, machine-readable watermark for AI content detection.
+**C2PA** provides verifiable provenance chain for paid/enterprise outputs.
 
 ## Key Limitations
 - No video generation (image only)

--- a/skills/banana/references/presets.md
+++ b/skills/banana/references/presets.md
@@ -16,9 +16,50 @@ Each preset is stored as `~/.banana/presets/NAME.json`:
   "lighting": "bright diffused studio, no harsh shadows",
   "mood": "professional, trustworthy, modern",
   "default_ratio": "16:9",
-  "default_resolution": "2K"
+  "default_resolution": "2K",
+
+  "_comment": "--- Brand Style Guide fields below (all optional) ---",
+  "background_styles": {
+    "dark-premium": {"bg": "#000000", "text": "#FFFFFF", "accent": "#2563EB"},
+    "light-clean": {"bg": "#F8FAFC", "text": "#1E40AF", "accent": "#2563EB"}
+  },
+  "visual_motifs": "subtle geometric grid pattern in light blue at 20% opacity",
+  "logo_placement": "bottom-left, 12% of width",
+  "do_list": ["Use generous white space", "Keep layouts clean and minimal", "Use brand blue for CTAs"],
+  "dont_list": ["No gradients on backgrounds", "No more than 2 accent colors", "No decorative fonts"],
+  "prompt_keywords": {
+    "aesthetic": ["clean", "minimal", "modern", "professional"],
+    "mood": ["trustworthy", "innovative", "approachable"],
+    "photography": ["bright", "high-key lighting", "sharp focus"]
+  },
+  "prompt_suffix": "Clean minimal tech aesthetic, bright diffused lighting, professional and trustworthy mood.",
+  "technical_specs": {"color_space": "sRGB", "min_dpi": 150}
 }
 ```
+
+### Field Reference
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | Yes | Unique preset identifier |
+| `description` | string | No | Brief description |
+| `colors` | string[] | No | Hex color palette |
+| `style` | string | No | Visual style description |
+| `typography` | string | No | Typography description |
+| `lighting` | string | No | Lighting description |
+| `mood` | string | No | Mood/emotion description |
+| `default_ratio` | string | No | Default aspect ratio |
+| `default_resolution` | string | No | Default resolution |
+| `background_styles` | object | No | Named background variants (each with bg/text/accent) |
+| `visual_motifs` | string | No | Pattern/overlay description with opacity |
+| `logo_placement` | string | No | Where the logo goes in post-production (NOT mentioned in prompts -- see logo exclusion rule) |
+| `do_list` | string[] | No | Brand guidelines to follow |
+| `dont_list` | string[] | No | Brand guidelines to avoid |
+| `prompt_keywords` | object | No | Categorized keywords to weave into prompts |
+| `prompt_suffix` | string | No | Appended verbatim to every prompt |
+| `technical_specs` | object | No | Technical defaults (color_space, min_dpi, etc.) |
+
+All Brand Style Guide fields (below the `_comment` line) are **optional**. Presets without them continue to work as before.
 
 ## Example Presets
 
@@ -40,6 +81,20 @@ Each preset is stored as `~/.banana/presets/NAME.json`:
 - **Typography:** Condensed all-caps sans-serif headlines
 - **Mood:** Bold, provocative, contemporary
 
+### premium-brand (Brand Style Guide)
+- **Colors:** #000000, #FFC000, #FFFFFF, #C0C0C0 (black + gold + white + silver)
+- **Style:** Premium dark photography, dramatic lighting, gold accents, editorial quality
+- **Typography:** Bold geometric sans-serif headlines, light weight body text
+- **Mood:** Confident, innovative, premium, forward-thinking
+- **Background styles:**
+  - `dark-premium`: pure black BG, white text, gold accent
+  - `gold-gradient`: gradient from #FFC000 to dark amber, black text
+- **Visual motifs:** Geometric network pattern in silver at 30-50% opacity
+- **Logo placement:** Bottom-left, 15% of width *(added in post-production, NOT mentioned in prompts)*
+- **Prompt suffix:** "Premium dark aesthetic with gold accents, dramatic lighting, confident and innovative mood."
+- **Do:** Use generous negative space, maintain high contrast, keep patterns subtle
+- **Don't:** Use busy backgrounds behind text, mix more than 2 accent colors, use white backgrounds
+
 ## How Presets Merge into Reasoning Brief
 
 When a preset is active, Claude uses its values as defaults for the Reasoning Brief:
@@ -51,6 +106,16 @@ When a preset is active, Claude uses its values as defaults for the Reasoning Br
 
 User instructions always override preset values. If a user says "make it dark"
 but the preset has bright lighting, follow the user's instruction.
+
+**Brand Style Guide additions** (when present):
+
+6. **background_styles** → if Presentation mode, select the matching background variant; apply its bg/text/accent colors
+7. **visual_motifs** → append motif description to the Style component at specified opacity
+8. **logo_placement** → records where logo goes in post-production. Do NOT mention "logo" in the prompt -- instead describe that area as "clean negative space" or "uncluttered background"
+9. **do_list / dont_list** → Claude checks the final prompt against these rules before sending
+10. **prompt_keywords** → weave relevant keywords from matching categories into the prompt naturally
+11. **prompt_suffix** → appended verbatim to the end of the constructed prompt
+12. **technical_specs** → override default_ratio and default_resolution if present; apply color_space
 
 ## Managing Presets
 

--- a/skills/banana/references/prompt-engineering.md
+++ b/skills/banana/references/prompt-engineering.md
@@ -124,7 +124,40 @@ Reminiscent of Dorothea Lange's documentary portraiture"
 
 ## Advanced Techniques
 
+### Start with Intent, Refine with Specs
+
+Nano Banana 2 is designed for conversational editing. Use a two-phase approach:
+
+**Phase 1 -- Intent (Initial Generation)**
+Start with a conceptual prompt that lets the model's thinking handle composition:
+- "A futuristic sports car on a rainy Tokyo street at night"
+- "A premium product shot of wireless earbuds for an e-commerce store"
+- "A cozy café interior for a lifestyle blog header"
+
+**Phase 2 -- Specs (Refinement via Edit/Chat)**
+Follow up with specific technical adjustments:
+- "Change the car to metallic red, add wet asphalt reflections"
+- "Use a lower camera angle, add dramatic rim lighting from the left"
+- "Make the wood tones warmer, add steam rising from the coffee cup"
+
+**The PEEL Strategy for adding specs:**
+| Component | What to specify | Example |
+|-----------|----------------|---------|
+| **P**osition | Camera angle, framing, subject placement | "Low-angle shot, subject on right third" |
+| **E**xpression | Emotion, mood, facial/body language | "Confident smile, relaxed posture" |
+| **E**nvironment | Setting, time, weather, atmosphere | "Golden hour rooftop, city skyline behind" |
+| **L**ens | Camera, focal length, depth of field | "85mm f/1.4, shallow depth of field" |
+
+**Use reference images instead of written specs** when describing style or texture.
+One reference image replaces paragraphs of description. Upload it and say
+"match the lighting style of this image" or "use this color palette."
+
+**When to front-load specs:** For photorealistic/cinema domain modes where camera
+and lighting are critical, include PEEL specs in the initial prompt. For simpler
+use cases, let the model interpret intent first.
+
 ### Character Consistency (Multi-turn)
+
 Use `gemini_chat` and maintain descriptive anchors:
 - First turn: Generate character with exhaustive physical description
 - Following turns: Reference "the same character" + repeat 2-3 key identifiers
@@ -135,6 +168,80 @@ Use `gemini_chat` and maintain descriptive anchors:
 - Assign distinct names to each character ("Character A: the red-haired knight")
 - Model preserves features across different angles, actions, and environments
 - Works best when reference images show the character from multiple angles
+
+**Identity-locked generation pattern:**
+Use a `CRITICAL CONSISTENCY REQUIREMENTS` block in prompts:
+```
+Create a professional portrait of the person from the reference image.
+
+CRITICAL CONSISTENCY REQUIREMENTS:
+- Maintain EXACT facial features, skin tone, and hair from reference
+- Keep their distinctive features identical across all scenes
+- Position them naturally in the new environment
+```
+
+**Group photos (up to 5 people):**
+- Assign positions: "Person 1 center, Persons 2-3 on left, Persons 4-5 on right"
+- Specify each person's expression and pose individually
+- Use medium shot (waist up) for best facial consistency
+- Maximum 5 people for high-fidelity consistency
+
+**Sequential storytelling (3-part visual story):**
+- Scene 1: Establish character with full physical description
+- Scene 2: Reference "the same person" + 2-3 key identifiers + new setting
+- Scene 3: Same reference pattern + final setting
+- Use consistent camera angle (three-quarter view) across all scenes
+- Specify "EXACTLY consistent" for critical features
+
+**YouTube thumbnails with character:**
+- Maintain facial features from reference image
+- Use exaggerated expressions (wide eyes, open mouth) for engagement
+- Position character on left 40% of frame, facing right toward content
+- Add text overlay separately: bold Impact-style font with thick stroke
+
+### Progressive Enhancement (Multi-Turn Workflow)
+
+For `/banana chat` sessions, build images in 4 phases:
+
+| Phase | Focus | Example Follow-Up |
+|-------|-------|-------------------|
+| 1. **Composition & Subject** | Get layout, subject, framing right | "Move the subject to the left third, zoom out slightly" |
+| 2. **Lighting & Atmosphere** | Refine mood, shadows, time of day | "Shift to golden hour lighting, add warm rim light from right" |
+| 3. **Details & Polish** | Add fine elements, props, textures | "Add steam from the coffee, a small plant in the background" |
+| 4. **Technical Adjustments** | Color grading, contrast, final polish | "Slightly desaturate, add a subtle warm color grade" |
+
+**Key principle:** Each phase preserves successful elements from previous phases.
+This is more cost-effective and produces better results than trying to specify
+everything in a single prompt.
+
+### Multilingual & Localization
+
+Nano Banana 2 supports text rendering in multiple languages.
+
+**Translation within images:**
+Generate the image in English first, then follow up:
+```
+Take the previous image and translate all text to Japanese.
+Keep all visual elements, layout, colors, and composition identical.
+Only change the text content. Ensure Japanese text fits naturally
+within the same space constraints.
+```
+
+**Cultural adaptation:**
+Provide cultural context explicitly for region-specific aesthetics:
+```
+Create a coffee shop poster for the Japanese market.
+Use Japanese aesthetic principles: generous negative space,
+natural elements, muted tones. Headline in hiragana: "朝の一杯"
+in an elegant brush-style font. Format: 2:3 portrait.
+```
+
+**Tips:**
+- Provide exact text strings in the target language rather than asking for translation
+- Specify cultural context explicitly (e.g., "Japanese design sensibility," "Brazilian visual culture")
+- For RTL languages (Arabic, Hebrew), specify text direction if layout matters
+- Generate and verify one language at a time for multi-language campaigns
+- Native speaker review is recommended for production content
 
 ### Style Transfer Without Reference Images
 Describe the target style exhaustively instead of referencing an image:
@@ -163,16 +270,31 @@ Gemini does NOT support negative prompts. Rephrase exclusions:
 - Instead of "not dark" → "brightly lit, high-key lighting"
 
 ### Search-Grounded Generation
-For images based on real-world data (weather, events, statistics),
-Gemini can use Google Search grounding to incorporate live information.
-Useful for infographics with current data.
+
+For images based on real-world data, Gemini can use Google Search grounding
+to incorporate live information. Available on Nano Banana 2 via the
+`googleSearch` tool configuration.
 
 **Three-part formula for search-grounded prompts:**
 1. `[Source/Search request]` -- What to look up
 2. `[Analytical task]` -- What to analyze or extract
 3. `[Visual translation]` -- How to render it as an image
 
-**Example:** "Search for the current top 5 programming languages by GitHub usage in 2026, analyze their relative popularity percentages, then generate a clean infographic bar chart with the language logos and percentages in a modern dark theme."
+**Examples:**
+
+| Use Case | Prompt Pattern |
+|----------|---------------|
+| Weather visualization | "Search for the current 5-day forecast for Tokyo, then generate a modern weather infographic showing each day with temperature, conditions, and clothing suggestions" |
+| Data comparison | "Search for the current top 5 programming languages by GitHub usage in 2026, analyze their relative popularity, then generate a clean infographic bar chart in a modern dark theme" |
+| Historical event | "Search for the key stages of the Apollo 11 mission, then create an educational timeline infographic with illustrations for each stage" |
+| Current events | "Search for today's major sports results, then create a visual scoreboard infographic in a bold, energetic style" |
+
+**Important:** Always verify factual accuracy of generated data visualizations.
+The model may approximate or hallucinate statistics -- treat search-grounded
+infographics as drafts requiring human verification.
+
+**API configuration:** Add `"tools": [{"googleSearch": {}}]` to the generation config.
+On Replicate, use the `google_search: true` parameter for `google/nano-banana-2`.
 
 ## ❌ BANNED PROMPT KEYWORDS -- NEVER USE THESE
 
@@ -270,6 +392,11 @@ to Gemini's natural language format:
 8. **Text longer than ~25 characters** -- Rendering degrades rapidly past this limit
 9. **Burying key details at the end** -- In long prompts, details placed last may be deprioritized; put critical specifics (exact text, key constraints) in the first third of the prompt
 10. **Not iterating with follow-up prompts** -- Use `gemini_chat` for progressive refinement instead of trying to get everything right in one generation
+11. **Contradictory instructions** -- "minimalist design with lots of intricate details" confuses the model. Pick one direction or specify a focal point: "minimalist design with one carefully chosen intricate detail as the focal point"
+12. **Impossible physics** -- "two different shadows in opposite directions from a single light source." Describe physically plausible lighting setups
+13. **Inconsistent style mixing** -- "photorealistic watercolor painting" is contradictory. Choose one: "photorealistic portrait" OR "watercolor painting portrait"
+14. **Aspect ratio mismatch** -- Requesting "tall vertical portrait" but setting 16:9 landscape ratio. Always align the ratio to the composition described in the prompt
+15. **Negative framing** -- "a beach scene with no people, no clouds, no rocks" -- the model has no negative prompts. Instead: "an empty, pristine beach with just white sand, calm turquoise water, and clear blue sky"
 
 ## Proven Prompt Templates
 

--- a/skills/banana/references/prompt-engineering.md
+++ b/skills/banana/references/prompt-engineering.md
@@ -122,6 +122,33 @@ Reminiscent of Dorothea Lange's documentary portraiture"
 **Color palettes:** analogous harmony, complementary clash, monochromatic gradient, neon-on-black
 **Styles:** generative art, data visualization art, glitch, procedural, macro photography of materials
 
+### Presentation Mode
+
+Presentation mode has **two generation options**:
+
+**Option A -- Complete Slide** (text rendered in the image):
+Use when the model should render headline/body text directly. Nano Banana 2 excels
+at text rendering (up to 25 chars per element). The output is a finished slide.
+
+**Option B -- Background Only** (for layering in Keynote/PPT/Slides):
+Use when text, logos, and UI elements will be added as separate layers in presentation
+software. The output is a clean background with intentional negative space.
+
+**Background styles:** dark premium (pure black #000000), gradient sweep (brand color to darker tone), split layout (half image / half solid), full-bleed image with dark overlay
+**Layout zones:** headline zone (top 20%), content zone (middle 55%), lower margin (bottom 25% -- clean negative space for later overlays)
+**Typography rendering (Complete mode only):** headline (bold sans-serif, 48-72pt equivalent), subheading (medium, 32-40pt), body (light, 24-32pt), caption (12-20pt)
+**Pattern overlays:** geometric network, connected nodes and lines, circuit mesh, dot grid -- all at 30-50% opacity in silver or white
+**Slide types:** title, content, quote/statement, image feature, section divider
+**Format:** always 16:9 widescreen, default 4K (3840x2160) for backgrounds
+**Color guidance:** high contrast pairs (white on black, black on gold), gradient transitions, accent colors sparingly
+**Style refs:** Apple Keynote, TED stage visuals, premium pitch decks, conference keynotes
+
+**CRITICAL -- Logo exclusion:** NEVER mention "logo," "logo placement," "branding mark,"
+or "reserve space for logo" in any Presentation prompt. The model will generate unwanted
+logo-like artifacts. Instead, describe the area as "clean negative space," "simple
+uncluttered background," or "generous breathing room." Logos are composited in
+presentation software after generation.
+
 ## Advanced Techniques
 
 ### Start with Intent, Refine with Specs
@@ -242,6 +269,26 @@ in an elegant brush-style font. Format: 2:3 portrait.
 - For RTL languages (Arabic, Hebrew), specify text direction if layout matters
 - Generate and verify one language at a time for multi-language campaigns
 - Native speaker review is recommended for production content
+
+### Brand Style Guide Integration
+
+When a loaded preset contains Brand Style Guide fields, apply them during prompt construction:
+
+**prompt_suffix:** Append verbatim after the Style component. The most direct brand influence on every generation.
+
+**prompt_keywords:** Weave keywords from relevant categories into the narrative naturally. Do not dump as a list -- integrate "premium" and "modern" into the Style component description.
+
+**visual_motifs:** Add motif description to Style or Context. In Presentation mode, include as pattern overlay with specified opacity. In other modes, use as subtle background texture.
+
+**background_styles:** In Presentation mode, select the variant matching the slide type:
+- Title slides → dark-premium or gradient variant
+- Content slides → variant with best readability for body text
+- Quote/statement → dark background for dramatic impact
+- User can override by naming a specific variant
+
+**do_list / dont_list:** Verify the final prompt aligns with do's and avoids don'ts. These are guardrails, not prompt components.
+
+**logo_placement:** This field records where the logo will be placed in post-production (e.g., "bottom-left, 15% of width"). Do NOT mention "logo" in the prompt. Instead, describe that area as "clean negative space" or "simple uncluttered background" so the model keeps it clear without generating logo-like artifacts. The logo is composited in Keynote/PowerPoint/Slides after image generation.
 
 ### Style Transfer Without Reference Images
 Describe the target style exhaustively instead of referencing an image:
@@ -544,6 +591,63 @@ label, surrounded by swirling gradient ribbons of teal and coral light.
 The bottle sits on a reflective dark surface, sharp studio rim lighting
 separating it from the background. Product photography for luxury
 branding, dramatic contrast. Wallpaper* magazine design editorial.
+```
+
+### Presentation / Slide
+
+Two generation patterns depending on whether text is rendered in the image or added later.
+
+#### Option A -- Complete Slide (text rendered by the model)
+
+**Pattern:** `[Background style] + [visual motif at opacity] + [rendered text with font description] + [color palette] + "16:9 widescreen presentation slide" + [mood/brand]`
+
+**Example (Complete Title Slide):**
+```
+A premium presentation title slide on a pure black background. The text
+"DIGITAL INNOVATION" is rendered in bold white condensed sans-serif at
+the top third, with the subtitle "Transforming the Future" in a lighter
+weight gold (#FFC000) font below it. A subtle geometric network pattern
+of connected silver nodes and thin lines at 30% opacity decorates the
+lower-right corner. Clean negative space throughout. 16:9 widescreen,
+4K resolution. Premium tech keynote aesthetic.
+```
+
+**Example (Complete Content Slide):**
+```
+A presentation slide with rich gold (#FFC000) gradient background fading
+to dark amber at the bottom. The headline "KEY FINDINGS" is rendered in
+bold black sans-serif in the upper-left. Below it, three bullet points
+in black regular-weight text: "94% accuracy rate", "3x faster workflow",
+"50% cost reduction". A faint dot grid pattern at 20% opacity overlays
+the gradient. 16:9 widescreen format. Modern corporate keynote style.
+```
+
+#### Option B -- Background Only (for layering in presentation software)
+
+**Pattern:** `[Background style] + [visual motif at opacity] + [describe negative space where text will go] + [color palette] + "16:9 widescreen slide background, NO text, NO logos, NO labels" + [mood/brand]`
+
+**CRITICAL:** Explicitly state "NO text, NO logos, NO labels, NO watermarks" in Background
+mode. Without this, the model may generate decorative text or logo-like shapes. Never
+mention logos even to say "leave space for" -- describe the area as clean background instead.
+
+**Example (Background-Only Dark Title):**
+```
+A dark premium slide background in pure black with generous clean negative
+space in the upper half and center. A subtle geometric network pattern of
+connected silver nodes and thin lines at 30% opacity in the lower-right
+quadrant. Simple, uncluttered lower-left corner with continued dark
+background. 16:9 widescreen, 4K resolution. NO text, NO logos, NO labels.
+Premium tech keynote aesthetic, Apple WWDC stage visual style.
+```
+
+**Example (Background-Only Gradient):**
+```
+A widescreen slide background with a smooth gradient sweep from rich gold
+(#FFC000) at the top transitioning to deep amber and dark charcoal at the
+bottom. A faint geometric dot grid at 20% opacity across the surface.
+Large open areas of clean gradient for content overlay. Simple uncluttered
+composition with generous breathing room. 16:9 format, 4K resolution.
+NO text, NO logos, NO labels. Premium corporate keynote background.
 ```
 
 ### Key Tactics That Make Prompts Work

--- a/skills/banana/references/replicate.md
+++ b/skills/banana/references/replicate.md
@@ -1,0 +1,108 @@
+# Replicate Backend Reference -- google/nano-banana-2
+
+> Alternative backend for image generation when MCP is unavailable or
+> for users who prefer Replicate's simpler authentication.
+>
+> Model: `google/nano-banana-2` (Gemini 3.1 Flash Image on Replicate)
+
+## Model Overview
+
+Nano Banana 2 on Replicate provides **Pro-level visual quality with Flash-level speed and pricing**.
+
+Key capabilities:
+- **Text rendering** in multiple languages with high accuracy
+- **Conversational editing** -- iterative refinement through natural dialogue
+- **Multi-image fusion** -- blend up to 14 reference images in a single composition
+- **Character consistency** -- maintain appearance of up to 5 people across images
+- **Search grounding** -- Google Web Search + Image Search for real-time data
+- **Resolutions** from 512px drafts to 4K production assets
+- **Extreme aspect ratios** -- 1:4, 4:1, 1:8, 8:1 in addition to standard ratios
+
+## When to Use Replicate
+
+| Scenario | Recommended Backend |
+|----------|-------------------|
+| MCP server configured and working | MCP (primary) |
+| MCP unavailable, have Replicate token | Replicate |
+| MCP unavailable, have Google AI key | Direct Gemini API |
+| Simpler auth needed (no Google Cloud) | Replicate |
+| Need webhook/async processing | Replicate |
+
+## Authentication
+
+Set the `REPLICATE_API_TOKEN` environment variable:
+```bash
+export REPLICATE_API_TOKEN="r8_your_token_here"
+```
+
+Or store in `~/.banana/config.json`:
+```json
+{"replicate_api_token": "r8_your_token_here"}
+```
+
+Get a token at: https://replicate.com/account/api-tokens
+
+## Input Parameters
+
+| Param | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `prompt` | string | Yes | — | Text description of the image |
+| `image_input` | array | No | `[]` | Reference images (up to 14), as URLs or base64 data URIs |
+| `aspect_ratio` | string | No | `match_input_image` | Aspect ratio (see below) |
+| `resolution` | string | No | `2K` | `512`, `1K`, `2K`, or `4K` |
+| `output_format` | string | No | `jpg` | `jpg` or `png` |
+| `google_search` | boolean | No | `false` | Enable Google Web Search grounding |
+| `image_search` | boolean | No | `false` | Enable Google Image Search grounding (auto-enables web search) |
+
+## Supported Aspect Ratios
+
+`1:1`, `2:3`, `3:2`, `3:4`, `4:3`, `4:5`, `5:4`, `9:16`, `16:9`, `21:9`, `1:4`, `4:1`, `1:8`, `8:1`, `match_input_image`
+
+## Output
+
+- **Type:** URL string pointing to the generated image
+- **Expiration:** URLs expire after ~24 hours — download immediately
+- **Watermark:** SynthID invisible watermark included on all outputs
+
+## CLI Usage
+
+**Generate:**
+```bash
+python3 scripts/replicate_generate.py --prompt "a sunset over mountains" --aspect-ratio "16:9" --resolution "2K"
+```
+
+**Edit:**
+```bash
+python3 scripts/replicate_edit.py --image path/to/photo.png --prompt "remove the background"
+```
+
+**With search grounding:**
+```bash
+python3 scripts/replicate_generate.py --prompt "current weather in Tokyo as an infographic" --google-search
+```
+
+## Pricing
+
+Replicate uses per-second compute pricing. Check https://replicate.com/pricing for current rates.
+Estimated ~$0.05 per image (varies by resolution and processing time).
+
+## Error Handling
+
+| Error | Cause | Resolution |
+|-------|-------|-----------|
+| HTTP 422 | Invalid input parameters | Check prompt, aspect ratio, resolution values |
+| HTTP 401 | Invalid API token | Verify REPLICATE_API_TOKEN |
+| HTTP 429 | Rate limited | Wait and retry with exponential backoff |
+| Prediction `failed` | Model error or content filtered | Check error message, rephrase prompt |
+| Prediction timeout | Model at capacity | Retry later or use direct Gemini API fallback |
+
+## Differences from Direct Gemini API
+
+| Feature | Replicate | Direct Gemini API |
+|---------|-----------|-------------------|
+| Auth | Bearer token (simple) | Google AI API key |
+| Image output | URL (download needed) | Base64 inline |
+| Search grounding | `google_search` boolean | `googleSearch` tool config |
+| Aspect ratio default | `match_input_image` | `1:1` |
+| Output format | `jpg` (default), `png`, `webp` | PNG only |
+| `imageSize` param | `resolution` | `imageSize` (UPPERCASE required) |

--- a/skills/banana/scripts/cost_tracker.py
+++ b/skills/banana/scripts/cost_tracker.py
@@ -31,6 +31,12 @@ PRICING = {
         "512": 0.020,
         "1K": 0.039,
     },
+    "replicate/nano-banana-2": {
+        "512": 0.050,
+        "1K": 0.050,
+        "2K": 0.050,
+        "4K": 0.050,
+    },
 }
 
 # Batch API gets 50% discount

--- a/skills/banana/scripts/presets.py
+++ b/skills/banana/scripts/presets.py
@@ -96,6 +96,36 @@ def cmd_create(args):
         "default_resolution": args.resolution or "2K",
     }
 
+    # Brand Style Guide fields (optional, backward-compatible)
+    if args.background_styles:
+        try:
+            preset["background_styles"] = json.loads(args.background_styles)
+        except json.JSONDecodeError:
+            print("Error: --background-styles must be valid JSON.", file=sys.stderr)
+            sys.exit(1)
+    if args.visual_motifs:
+        preset["visual_motifs"] = args.visual_motifs
+    if args.logo_placement:
+        preset["logo_placement"] = args.logo_placement
+    if args.do_list:
+        preset["do_list"] = [item.strip() for item in args.do_list.split(",")]
+    if args.dont_list:
+        preset["dont_list"] = [item.strip() for item in args.dont_list.split(",")]
+    if args.prompt_keywords:
+        try:
+            preset["prompt_keywords"] = json.loads(args.prompt_keywords)
+        except json.JSONDecodeError:
+            print("Error: --prompt-keywords must be valid JSON.", file=sys.stderr)
+            sys.exit(1)
+    if args.prompt_suffix:
+        preset["prompt_suffix"] = args.prompt_suffix
+    if args.technical_specs:
+        try:
+            preset["technical_specs"] = json.loads(args.technical_specs)
+        except json.JSONDecodeError:
+            print("Error: --technical-specs must be valid JSON.", file=sys.stderr)
+            sys.exit(1)
+
     with open(path, "w") as f:
         json.dump(preset, f, indent=2)
 
@@ -139,6 +169,15 @@ def main():
     p_create.add_argument("--ratio", default="16:9", help="Default aspect ratio")
     p_create.add_argument("--resolution", default="2K", help="Default resolution")
     p_create.add_argument("--force", action="store_true", help="Overwrite existing preset")
+    # Brand Style Guide fields (optional)
+    p_create.add_argument("--background-styles", default="", help="JSON string of named background variants")
+    p_create.add_argument("--visual-motifs", default="", help="Pattern/overlay description")
+    p_create.add_argument("--logo-placement", default="", help="Logo placement description")
+    p_create.add_argument("--do-list", default="", help="Comma-separated brand do's")
+    p_create.add_argument("--dont-list", default="", help="Comma-separated brand don'ts")
+    p_create.add_argument("--prompt-keywords", default="", help="JSON string of categorized keywords")
+    p_create.add_argument("--prompt-suffix", default="", help="Suffix appended to every prompt")
+    p_create.add_argument("--technical-specs", default="", help="JSON string of technical defaults")
 
     # delete
     p_delete = sub.add_parser("delete", help="Delete a preset")

--- a/skills/banana/scripts/replicate_edit.py
+++ b/skills/banana/scripts/replicate_edit.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Banana Claude -- Replicate API Fallback: Image Editing
+
+Edit images via Replicate API using google/nano-banana-2.
+Uses only Python stdlib (no pip dependencies).
+
+Usage:
+    replicate_edit.py --image path/to/image.png --prompt "remove the background"
+                      [--aspect-ratio match_input_image] [--resolution 2K]
+                      [--output-format png] [--api-key KEY]
+"""
+
+import argparse
+import base64
+import json
+import os
+import sys
+import time
+import urllib.request
+from datetime import datetime
+from pathlib import Path
+
+MODEL = "google/nano-banana-2"
+OUTPUT_DIR = Path.home() / "Documents" / "nanobanana_generated"
+API_BASE = "https://api.replicate.com/v1/models"
+POLL_TIMEOUT = 300  # seconds
+
+VALID_RESOLUTIONS = {"512", "1K", "2K", "4K"}
+VALID_OUTPUT_FORMATS = {"jpg", "png"}
+
+
+def _load_config_key():
+    """Try to load REPLICATE_API_TOKEN from ~/.banana/config.json."""
+    config_path = Path.home() / ".banana" / "config.json"
+    if config_path.exists():
+        try:
+            with open(config_path) as f:
+                cfg = json.load(f)
+            return cfg.get("REPLICATE_API_TOKEN") or cfg.get("replicate_api_token")
+        except (json.JSONDecodeError, OSError):
+            pass
+    return None
+
+
+def _api_request(url, api_key, data=None, method="GET"):
+    """Make an authenticated request to the Replicate API."""
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+    body = json.dumps(data).encode("utf-8") if data else None
+    req = urllib.request.Request(url, data=body, headers=headers, method=method)
+
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def edit_image(image_path, prompt, aspect_ratio, resolution, output_format, api_key):
+    """Call Replicate API to edit an image."""
+    image_path = Path(image_path).resolve()
+    if not image_path.exists():
+        print(json.dumps({"error": True, "message": f"Image not found: {image_path}"}))
+        sys.exit(1)
+
+    # Read and encode image
+    with open(image_path, "rb") as f:
+        image_b64 = base64.b64encode(f.read()).decode("utf-8")
+
+    # Determine MIME type
+    suffix = image_path.suffix.lower()
+    mime_types = {".png": "image/png", ".jpg": "image/jpeg", ".jpeg": "image/jpeg",
+                  ".webp": "image/webp"}
+    mime_type = mime_types.get(suffix, "image/png")
+
+    # Format as data URI
+    data_uri = f"data:{mime_type};base64,{image_b64}"
+
+    # POST to create prediction
+    create_url = f"{API_BASE}/{MODEL}/predictions"
+    body = {
+        "input": {
+            "prompt": prompt,
+            "image_input": [data_uri],
+            "aspect_ratio": aspect_ratio,
+            "resolution": resolution,
+            "output_format": output_format,
+        }
+    }
+
+    max_retries = 3
+    prediction = None
+    for attempt in range(max_retries):
+        try:
+            prediction = _api_request(create_url, api_key, data=body, method="POST")
+            break
+        except urllib.error.HTTPError as e:
+            error_body = e.read().decode("utf-8") if e.fp else ""
+            if e.code == 422:
+                print(json.dumps({"error": True, "status": 422, "message": f"Invalid input: {error_body}"}))
+                sys.exit(1)
+            if e.code == 429 and attempt < max_retries - 1:
+                wait = 2 ** (attempt + 1)
+                print(json.dumps({"retry": True, "attempt": attempt + 1, "wait_seconds": wait, "reason": "rate_limited"}), file=sys.stderr)
+                time.sleep(wait)
+                continue
+            print(json.dumps({"error": True, "status": e.code, "message": error_body}))
+            sys.exit(1)
+        except urllib.error.URLError as e:
+            print(json.dumps({"error": True, "message": str(e.reason)}))
+            sys.exit(1)
+
+    if prediction is None:
+        print(json.dumps({"error": True, "message": "Max retries exceeded creating prediction"}))
+        sys.exit(1)
+
+    # Poll until succeeded or failed
+    poll_url = prediction.get("urls", {}).get("get")
+    if not poll_url:
+        # Fall back to constructing the URL from the prediction id
+        pred_id = prediction.get("id")
+        if not pred_id:
+            print(json.dumps({"error": True, "message": "No prediction ID in response", "response": prediction}))
+            sys.exit(1)
+        poll_url = f"https://api.replicate.com/v1/predictions/{pred_id}"
+
+    start_time = time.time()
+    poll_interval = 1.0
+    while True:
+        elapsed = time.time() - start_time
+        if elapsed > POLL_TIMEOUT:
+            print(json.dumps({"error": True, "message": f"Prediction timed out after {POLL_TIMEOUT}s"}))
+            sys.exit(1)
+
+        try:
+            status_resp = _api_request(poll_url, api_key, method="GET")
+        except urllib.error.HTTPError as e:
+            error_body = e.read().decode("utf-8") if e.fp else ""
+            print(json.dumps({"error": True, "status": e.code, "message": f"Poll failed: {error_body}"}))
+            sys.exit(1)
+        except urllib.error.URLError as e:
+            print(json.dumps({"error": True, "message": f"Poll failed: {e.reason}"}))
+            sys.exit(1)
+
+        status = status_resp.get("status")
+
+        if status == "succeeded":
+            output = status_resp.get("output")
+            break
+        elif status == "failed":
+            error_msg = status_resp.get("error", "Unknown error")
+            print(json.dumps({"error": True, "message": f"Prediction failed: {error_msg}"}))
+            sys.exit(1)
+        elif status == "canceled":
+            print(json.dumps({"error": True, "message": "Prediction was canceled"}))
+            sys.exit(1)
+
+        time.sleep(poll_interval)
+        # Exponential backoff on polling, cap at 5s
+        poll_interval = min(poll_interval * 1.5, 5.0)
+
+    # Download the output image
+    if not output:
+        print(json.dumps({"error": True, "message": "No output in succeeded prediction"}))
+        sys.exit(1)
+
+    # Output can be a string URL or a list of URLs
+    image_url = output[0] if isinstance(output, list) else output
+
+    try:
+        req = urllib.request.Request(image_url)
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            image_bytes = resp.read()
+    except (urllib.error.HTTPError, urllib.error.URLError) as e:
+        print(json.dumps({"error": True, "message": f"Failed to download output image: {e}"}))
+        sys.exit(1)
+
+    # Save image
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
+    ext = output_format if output_format in {"png", "jpg", "webp"} else "png"
+    filename = f"banana_edit_{timestamp}.{ext}"
+    output_path = (OUTPUT_DIR / filename).resolve()
+
+    with open(output_path, "wb") as f:
+        f.write(image_bytes)
+
+    return {
+        "path": str(output_path),
+        "model": MODEL,
+        "source": str(image_path),
+        "backend": "replicate",
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Edit images via Replicate API (google/nano-banana-2)")
+    parser.add_argument("--image", required=True, help="Path to input image")
+    parser.add_argument("--prompt", required=True, help="Edit instruction")
+    parser.add_argument("--aspect-ratio", default="match_input_image", help="Aspect ratio (default: match_input_image)")
+    parser.add_argument("--resolution", default="2K", help="Resolution: 1K, 2K, 4K (default: 2K)")
+    parser.add_argument("--output-format", default="png", help="Output format: jpg, png, webp (default: png)")
+    parser.add_argument("--api-key", default=None, help="Replicate API token (or set REPLICATE_API_TOKEN env)")
+
+    args = parser.parse_args()
+
+    if args.resolution not in VALID_RESOLUTIONS:
+        print(json.dumps({"error": True, "message": f"Invalid resolution '{args.resolution}'. Valid: {sorted(VALID_RESOLUTIONS)}"}))
+        sys.exit(1)
+
+    if args.output_format not in VALID_OUTPUT_FORMATS:
+        print(json.dumps({"error": True, "message": f"Invalid output format '{args.output_format}'. Valid: {sorted(VALID_OUTPUT_FORMATS)}"}))
+        sys.exit(1)
+
+    api_key = args.api_key or os.environ.get("REPLICATE_API_TOKEN") or _load_config_key()
+    if not api_key:
+        print(json.dumps({"error": True, "message": "No API key. Set REPLICATE_API_TOKEN env, pass --api-key, or add to ~/.banana/config.json"}))
+        sys.exit(1)
+
+    result = edit_image(
+        image_path=args.image,
+        prompt=args.prompt,
+        aspect_ratio=args.aspect_ratio,
+        resolution=args.resolution,
+        output_format=args.output_format,
+        api_key=api_key,
+    )
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/banana/scripts/replicate_generate.py
+++ b/skills/banana/scripts/replicate_generate.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""Banana Claude -- Replicate API Backend: Image Generation
+
+Generate images via the Replicate API using google/nano-banana-2.
+Uses only Python stdlib (no pip dependencies).
+
+Usage:
+    replicate_generate.py --prompt "a cat in space" [--aspect-ratio 16:9] [--resolution 2K]
+                          [--output-format png] [--image-input img.png] [--api-key KEY]
+                          [--google-search] [--image-search]
+"""
+
+import argparse
+import base64
+import json
+import mimetypes
+import os
+import sys
+import time
+import urllib.request
+from datetime import datetime
+from pathlib import Path
+
+MODEL = "google/nano-banana-2"
+DEFAULT_RESOLUTION = "2K"
+DEFAULT_RATIO = "1:1"
+DEFAULT_FORMAT = "png"
+OUTPUT_DIR = Path.home() / "Documents" / "nanobanana_generated"
+API_BASE = "https://api.replicate.com/v1/models"
+POLL_TIMEOUT = 300  # seconds
+
+VALID_RATIOS = {"1:1", "16:9", "9:16", "4:3", "3:4", "2:3", "3:2",
+                "4:5", "5:4", "21:9", "1:4", "4:1", "1:8", "8:1",
+                "match_input_image"}
+VALID_RESOLUTIONS = {"512", "1K", "2K", "4K"}
+VALID_FORMATS = {"jpg", "png"}
+MAX_IMAGE_INPUTS = 14
+
+
+def _load_config_token():
+    """Try to read replicate_api_token from ~/.banana/config.json."""
+    config_path = Path.home() / ".banana" / "config.json"
+    if config_path.is_file():
+        try:
+            with open(config_path, "r") as f:
+                data = json.load(f)
+            return data.get("replicate_api_token")
+        except (json.JSONDecodeError, OSError):
+            pass
+    return None
+
+
+def _resolve_api_key(cli_key):
+    """Resolve API key: CLI arg > env var > config file."""
+    if cli_key:
+        return cli_key
+    env_key = os.environ.get("REPLICATE_API_TOKEN")
+    if env_key:
+        return env_key
+    return _load_config_token()
+
+
+def _encode_image(path):
+    """Read an image file and return a data URI string."""
+    p = Path(path).expanduser().resolve()
+    if not p.is_file():
+        print(json.dumps({"error": True, "message": f"Image file not found: {path}"}))
+        sys.exit(1)
+    mime, _ = mimetypes.guess_type(str(p))
+    if not mime or not mime.startswith("image/"):
+        mime = "image/png"
+    with open(p, "rb") as f:
+        data = base64.b64encode(f.read()).decode("ascii")
+    return f"data:{mime};base64,{data}"
+
+
+def _api_request(url, api_key, method="GET", body=None):
+    """Make an authenticated request to the Replicate API."""
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+    data = json.dumps(body).encode("utf-8") if body else None
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+
+    with urllib.request.urlopen(req, timeout=120) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def create_prediction(prompt, aspect_ratio, resolution, output_format,
+                      image_input_uris, google_search, image_search, api_key):
+    """Create a prediction on Replicate and poll until complete."""
+    url = f"{API_BASE}/{MODEL}/predictions"
+
+    body = {
+        "input": {
+            "prompt": prompt,
+            "aspect_ratio": aspect_ratio,
+            "resolution": resolution,
+            "output_format": output_format,
+            "image_input": image_input_uris,
+            "google_search": google_search,
+            "image_search": image_search,
+        }
+    }
+
+    # --- Submit prediction with retry logic ---
+    max_retries = 3
+    prediction = None
+    for attempt in range(max_retries):
+        try:
+            prediction = _api_request(url, api_key, method="POST", body=body)
+            break
+        except urllib.error.HTTPError as e:
+            error_body = e.read().decode("utf-8") if e.fp else ""
+            if e.code == 429 and attempt < max_retries - 1:
+                wait = 2 ** (attempt + 1)
+                print(json.dumps({"retry": True, "attempt": attempt + 1, "wait_seconds": wait, "reason": "rate_limited"}), file=sys.stderr)
+                time.sleep(wait)
+                continue
+            if e.code == 422:
+                print(json.dumps({"error": True, "status": 422, "message": f"Invalid input: {error_body}"}))
+                sys.exit(1)
+            print(json.dumps({"error": True, "status": e.code, "message": error_body}))
+            sys.exit(1)
+        except urllib.error.URLError as e:
+            print(json.dumps({"error": True, "message": str(e.reason)}))
+            sys.exit(1)
+
+    if prediction is None:
+        print(json.dumps({"error": True, "message": "Max retries exceeded"}))
+        sys.exit(1)
+
+    # --- Poll for completion ---
+    poll_url = prediction.get("urls", {}).get("get")
+    if not poll_url:
+        print(json.dumps({"error": True, "message": "No polling URL in prediction response"}))
+        sys.exit(1)
+
+    start_time = time.time()
+    while True:
+        elapsed = time.time() - start_time
+        if elapsed > POLL_TIMEOUT:
+            print(json.dumps({"error": True, "message": f"Prediction timed out after {POLL_TIMEOUT} seconds"}))
+            sys.exit(1)
+
+        try:
+            status_resp = _api_request(poll_url, api_key, method="GET")
+        except urllib.error.HTTPError as e:
+            error_body = e.read().decode("utf-8") if e.fp else ""
+            print(json.dumps({"error": True, "status": e.code, "message": f"Poll error: {error_body}"}))
+            sys.exit(1)
+        except urllib.error.URLError as e:
+            print(json.dumps({"error": True, "message": f"Poll error: {e.reason}"}))
+            sys.exit(1)
+
+        status = status_resp.get("status")
+        if status == "succeeded":
+            return status_resp
+        elif status == "failed":
+            error_msg = status_resp.get("error", "Unknown error")
+            print(json.dumps({"error": True, "message": f"Prediction failed: {error_msg}"}))
+            sys.exit(1)
+        elif status == "canceled":
+            print(json.dumps({"error": True, "message": "Prediction was canceled"}))
+            sys.exit(1)
+
+        # Backoff: poll every 2 seconds
+        time.sleep(2)
+
+
+def download_image(image_url, output_format):
+    """Download the generated image and save it locally."""
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
+    ext = output_format if output_format in VALID_FORMATS else "png"
+    filename = f"banana_{timestamp}.{ext}"
+    output_path = (OUTPUT_DIR / filename).resolve()
+
+    req = urllib.request.Request(image_url)
+    with urllib.request.urlopen(req, timeout=120) as resp:
+        image_data = resp.read()
+
+    with open(output_path, "wb") as f:
+        f.write(image_data)
+
+    return str(output_path)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate images via Replicate API (google/nano-banana-2)")
+    parser.add_argument("--prompt", required=True, help="Image generation prompt")
+    parser.add_argument("--image-input", action="append", default=None,
+                        help="Path to a reference image (can be repeated, max 14)")
+    parser.add_argument("--aspect-ratio", default=DEFAULT_RATIO,
+                        help=f"Aspect ratio (default: {DEFAULT_RATIO})")
+    parser.add_argument("--resolution", default=DEFAULT_RESOLUTION,
+                        help=f"Resolution: 1K, 2K, 4K (default: {DEFAULT_RESOLUTION})")
+    parser.add_argument("--output-format", default=DEFAULT_FORMAT,
+                        help=f"Output format: jpg, png, webp (default: {DEFAULT_FORMAT})")
+    parser.add_argument("--google-search", action="store_true",
+                        help="Enable Google Web Search grounding")
+    parser.add_argument("--image-search", action="store_true",
+                        help="Enable Google Image Search grounding")
+    parser.add_argument("--api-key", default=None,
+                        help="Replicate API token (or set REPLICATE_API_TOKEN env)")
+
+    args = parser.parse_args()
+
+    # Validate arguments
+    if args.aspect_ratio not in VALID_RATIOS:
+        print(json.dumps({"error": True, "message": f"Invalid aspect ratio '{args.aspect_ratio}'. Valid: {sorted(VALID_RATIOS)}"}))
+        sys.exit(1)
+
+    if args.resolution not in VALID_RESOLUTIONS:
+        print(json.dumps({"error": True, "message": f"Invalid resolution '{args.resolution}'. Valid: {sorted(VALID_RESOLUTIONS)}"}))
+        sys.exit(1)
+
+    if args.output_format not in VALID_FORMATS:
+        print(json.dumps({"error": True, "message": f"Invalid output format '{args.output_format}'. Valid: {sorted(VALID_FORMATS)}"}))
+        sys.exit(1)
+
+    image_inputs = args.image_input or []
+    if len(image_inputs) > MAX_IMAGE_INPUTS:
+        print(json.dumps({"error": True, "message": f"Too many image inputs ({len(image_inputs)}). Maximum is {MAX_IMAGE_INPUTS}."}))
+        sys.exit(1)
+
+    api_key = _resolve_api_key(args.api_key)
+    if not api_key:
+        print(json.dumps({"error": True, "message": "No API key. Set REPLICATE_API_TOKEN env or pass --api-key"}))
+        sys.exit(1)
+
+    # Encode reference images as data URIs
+    image_input_uris = [_encode_image(p) for p in image_inputs]
+
+    # Create prediction and wait for result
+    result = create_prediction(
+        prompt=args.prompt,
+        aspect_ratio=args.aspect_ratio,
+        resolution=args.resolution,
+        output_format=args.output_format,
+        image_input_uris=image_input_uris,
+        google_search=args.google_search,
+        image_search=args.image_search,
+        api_key=api_key,
+    )
+
+    # Download generated image
+    output_url = result.get("output")
+    if not output_url or not isinstance(output_url, str):
+        print(json.dumps({"error": True, "message": f"Unexpected output format: {output_url}"}))
+        sys.exit(1)
+
+    saved_path = download_image(output_url, args.output_format)
+
+    # Print result JSON to stdout
+    print(json.dumps({
+        "path": saved_path,
+        "model": MODEL,
+        "aspect_ratio": args.aspect_ratio,
+        "resolution": args.resolution,
+        "backend": "replicate",
+    }, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/banana/scripts/setup_mcp.py
+++ b/skills/banana/scripts/setup_mcp.py
@@ -3,14 +3,16 @@
 Setup script for Banana Claude MCP server in Claude Code.
 
 Configures @ycse/nanobanana-mcp in Claude Code's settings.json
-with the user's Google AI API key.
+with the user's Google AI API key. Also manages Replicate backend config.
 
 Usage:
-    python3 setup_mcp.py                    # Interactive (prompts for key)
-    python3 setup_mcp.py --key YOUR_KEY     # Non-interactive
-    python3 setup_mcp.py --check            # Verify existing setup
-    python3 setup_mcp.py --remove           # Remove MCP config
-    python3 setup_mcp.py --help             # Show usage
+    python3 setup_mcp.py                          # Interactive (prompts for key)
+    python3 setup_mcp.py --key YOUR_KEY           # Non-interactive
+    python3 setup_mcp.py --check                  # Verify existing MCP setup
+    python3 setup_mcp.py --remove                 # Remove MCP configuration
+    python3 setup_mcp.py --replicate-key TOKEN    # Set Replicate API token
+    python3 setup_mcp.py --check-replicate        # Verify Replicate setup
+    python3 setup_mcp.py --help                   # Show usage
 """
 
 import json
@@ -19,6 +21,7 @@ import os
 from pathlib import Path
 
 SETTINGS_PATH = Path.home() / ".claude" / "settings.json"
+BANANA_CONFIG = Path.home() / ".banana" / "config.json"
 MCP_NAME = "nanobanana-mcp"
 MCP_PACKAGE = "@ycse/nanobanana-mcp"
 DEFAULT_MODEL = "gemini-3.1-flash-image-preview"
@@ -70,6 +73,48 @@ def remove_mcp() -> None:
         print(f"'{MCP_NAME}' not found in settings.")
 
 
+def load_banana_config():
+    if not BANANA_CONFIG.exists():
+        return {}
+    with open(BANANA_CONFIG, "r") as f:
+        return json.load(f)
+
+
+def save_banana_config(config):
+    BANANA_CONFIG.parent.mkdir(parents=True, exist_ok=True)
+    with open(BANANA_CONFIG, "w") as f:
+        json.dump(config, f, indent=2)
+
+
+def setup_replicate(api_token):
+    if not api_token or not api_token.strip():
+        print("Error: Replicate API token cannot be empty.")
+        sys.exit(1)
+    config = load_banana_config()
+    config["replicate_api_token"] = api_token.strip()
+    save_banana_config(config)
+    print(f"Replicate API token saved to {BANANA_CONFIG}")
+    print(f"Get a token at: https://replicate.com/account/api-tokens")
+
+
+def check_replicate():
+    config = load_banana_config()
+    token = config.get("replicate_api_token", "")
+    if token:
+        masked = token[:8] + "..." + token[-4:] if len(token) > 12 else "(set)"
+        print(f"Replicate API token: {masked}")
+        return True
+    env_token = os.environ.get("REPLICATE_API_TOKEN", "")
+    if env_token:
+        masked = env_token[:8] + "..." + env_token[-4:] if len(env_token) > 12 else "(set)"
+        print(f"Replicate API token (from env): {masked}")
+        return True
+    print("Replicate API token: NOT configured")
+    print("  Set with: python3 setup_mcp.py --replicate-key YOUR_TOKEN")
+    print("  Or set REPLICATE_API_TOKEN env var")
+    return False
+
+
 def setup_mcp(api_key: str) -> None:
     """Configure MCP server in Claude Code settings."""
     if not api_key or not api_key.strip():
@@ -105,14 +150,25 @@ def main() -> None:
     if "--help" in args or "-h" in args:
         print("Usage: python3 setup_mcp.py [OPTIONS]")
         print()
-        print("Options:")
-        print("  --key KEY        Provide API key non-interactively")
-        print("  --check          Verify existing setup")
-        print("  --remove         Remove MCP configuration")
-        print("  --help, -h       Show this help message")
+        print("MCP Options:")
+        print("  --key KEY              Provide Google AI API key non-interactively")
+        print("  --check                Verify existing MCP setup")
+        print("  --remove               Remove MCP configuration")
         print()
-        print("Get a free API key at: https://aistudio.google.com/apikey")
+        print("Replicate Options:")
+        print("  --replicate-key TOKEN  Set Replicate API token (stored in ~/.banana/config.json)")
+        print("  --check-replicate      Verify Replicate setup")
+        print()
+        print("General:")
+        print("  --help, -h             Show this help message")
+        print()
+        print("Get a free Google AI API key at: https://aistudio.google.com/apikey")
+        print("Get a Replicate token at: https://replicate.com/account/api-tokens")
         sys.exit(0)
+
+    if "--check-replicate" in args:
+        check_replicate()
+        return
 
     if "--check" in args:
         check_setup()
@@ -121,6 +177,12 @@ def main() -> None:
     if "--remove" in args:
         remove_mcp()
         return
+
+    # Handle --replicate-key
+    for i, arg in enumerate(args):
+        if arg == "--replicate-key" and i + 1 < len(args):
+            setup_replicate(args[i + 1])
+            return
 
     # Get API key
     api_key = None


### PR DESCRIPTION
## Summary

Adds Replicate API (`google/nano-banana-2`) as a fallback backend, incorporates research-driven prompt engineering improvements, and corrects model specs from official Google docs (March 2026).

## Changes

- Add `scripts/replicate_generate.py` and `scripts/replicate_edit.py` (stdlib-only, zero pip deps)
- Add `references/replicate.md` (full Replicate backend reference)
- Add 5-Input Creative Brief system, Edit-First principle, PEEL strategy, prompt variations
- Expand prompt-engineering.md: progressive enhancement, multilingual, character consistency, pitfalls, search grounding
- Update gemini-models.md: resolution pixel tables, input limits, watermark tiers, thinking visibility, corrected output tokens (2,520 not 1,290)
- Add Replicate key management to `setup_mcp.py` (`--replicate-key`, `--check-replicate`)
- Add Replicate pricing to `cost_tracker.py` and `cost-tracking.md`
- Fix pre-existing rate limit inconsistency in cost-tracking.md (~10/~500 → ~5-15/~20-500)
- Fallback order: MCP → Direct Gemini API → Replicate
- Version bump to 1.4.2 in all 4 required files

## Checklist

- [x] SKILL.md stays under 500 lines / 5,000 tokens (410 lines, ~2,905 words)
- [x] Rate limits, model names, and aspect ratios are consistent across all files
- [x] `claude --plugin-dir .` tested
- [x] No secrets or API keys committed