### PR TITLE
fix(cost-tracker): the image cost ledger loses concurrent writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **The image cost ledger lost concurrent writes (`cost_tracker.py`).**
+  `skills/banana/scripts/cost_tracker.py` read and wrote `~/.banana/costs.json` with no
+  file locking on any platform and a non-atomic write, so two concurrent `log` calls both
+  read the same ledger and the second silently overwrote the first. Measured 4 entries
+  lost out of 20 concurrent `log` calls, with 3 of those processes crashing outright with
+  `JSONDecodeError` after reading a half-written file. It is easy to miss because the
+  ledger carries running aggregates (`total_cost`, `total_images`, `daily`) incremented
+  in the same write as the entry, so a lost write drops both together and the file stays
+  internally self-consistent while under-reporting. One exclusive lock now spans the
+  entire read-modify-write in `log`.
+- **No locking primitive is no longer treated as "proceed unlocked".** Locking uses
+  `fcntl` on POSIX and falls back to `msvcrt` on Windows; when neither is importable the
+  operation fails loudly instead of running unlocked.
+- **Ledger writes are atomic** (`tempfile.mkstemp` plus `os.replace`), so a crash
+  mid-write can no longer leave a truncated, unparseable ledger. A corrupt ledger now
+  fails closed with an actionable message and the file left in place for inspection,
+  instead of a bare traceback. `reset` takes the lock but deliberately does not read
+  first, so it still works as the recovery path for a corrupt ledger.
+- **`BANANA_HOME`** now overrides the ledger location, so the ledger's behaviour can be
+  exercised without touching a real spend history.
+
 ## [1.4.1] - 2026-03-27
 
 ### Changed

--- a/skills/banana/scripts/cost_tracker.py
+++ b/skills/banana/scripts/cost_tracker.py
@@ -13,11 +13,33 @@ Usage:
 
 import argparse
 import json
+import os
 import sys
+import tempfile
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 
-LEDGER_PATH = Path.home() / ".banana" / "costs.json"
+try:
+    import fcntl
+except ImportError:
+    fcntl = None
+
+try:
+    import msvcrt
+except ImportError:
+    msvcrt = None
+
+# BANANA_HOME lets tests (and anyone running an isolated budget) point the
+# ledger somewhere other than the real one. Resolved at import.
+BANANA_DIR = Path(os.environ.get("BANANA_HOME") or Path.home() / ".banana")
+LEDGER_PATH = BANANA_DIR / "costs.json"
+LOCK_PATH = BANANA_DIR / "costs.lock"
+
+
+def _empty_ledger():
+    return {"total_cost": 0.0, "total_images": 0, "entries": [], "daily": {}}
+
 
 # Cost per image in USD (approximate, based on ~1,290 output tokens)
 PRICING = {
@@ -37,19 +59,113 @@ PRICING = {
 BATCH_DISCOUNT = 0.5
 
 
-def _load_ledger():
-    """Load the cost ledger from disk."""
+class LedgerError(RuntimeError):
+    """The cost ledger could not be read or written safely."""
+
+
+def _lock(handle, exclusive):
+    """Take an advisory lock on an open handle, blocking until acquired.
+
+    Never degrades to running unlocked: a cost ledger that silently drops
+    entries is worse than one that refuses to run.
+    """
+    if fcntl is not None:
+        fcntl.flock(handle, fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH)
+    elif msvcrt is not None:
+        # msvcrt has no shared mode, so readers take an exclusive lock too.
+        # LK_LOCK retries 10 times at 1s intervals, then raises OSError.
+        handle.seek(0)
+        msvcrt.locking(handle.fileno(), msvcrt.LK_LOCK, 1)
+    else:
+        raise LedgerError(
+            "No file-locking primitive available (neither fcntl nor msvcrt). "
+            "Refusing to touch the cost ledger unlocked."
+        )
+
+
+def _unlock(handle):
+    if fcntl is not None:
+        fcntl.flock(handle, fcntl.LOCK_UN)
+    elif msvcrt is not None:
+        handle.seek(0)
+        msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+
+
+def _read_ledger():
+    """Read the ledger. Caller must hold the lock."""
     if not LEDGER_PATH.exists():
-        return {"total_cost": 0.0, "total_images": 0, "entries": [], "daily": {}}
-    with open(LEDGER_PATH, "r") as f:
-        return json.load(f)
+        return _empty_ledger()
+    try:
+        with open(LEDGER_PATH, "r") as f:
+            ledger = json.load(f)
+    except json.JSONDecodeError as exc:
+        raise LedgerError(
+            f"Cost ledger {LEDGER_PATH} is not valid JSON ({exc}). Refusing to "
+            "continue from a zero balance, which would under-report spend. "
+            "Inspect the file, then repair or remove it."
+        ) from exc
+    if not isinstance(ledger, dict) or not isinstance(ledger.get("entries"), list):
+        raise LedgerError(
+            f"Cost ledger {LEDGER_PATH} has an unexpected shape (no 'entries' "
+            "list). Inspect the file, then repair or remove it."
+        )
+    # Tolerate ledgers written before a field existed.
+    ledger.setdefault("total_cost", 0.0)
+    ledger.setdefault("total_images", 0)
+    ledger.setdefault("daily", {})
+    return ledger
 
 
-def _save_ledger(ledger):
-    """Save the cost ledger to disk."""
-    LEDGER_PATH.parent.mkdir(parents=True, exist_ok=True)
-    with open(LEDGER_PATH, "w") as f:
-        json.dump(ledger, f, indent=2)
+def _write_ledger(ledger):
+    """Write the ledger atomically. Caller must hold the exclusive lock.
+
+    tempfile + os.replace so a crash mid-write can never leave a truncated,
+    unparseable ledger behind.
+    """
+    BANANA_DIR.mkdir(parents=True, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(dir=str(BANANA_DIR), prefix=".costs.", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(ledger, f, indent=2)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_path, LEDGER_PATH)
+    except Exception:
+        if os.path.exists(tmp_path):
+            os.unlink(tmp_path)
+        raise
+
+
+@contextmanager
+def _locked_ledger(write=False):
+    """Yield the ledger under ONE lock held across the whole read-modify-write.
+
+    Reading under one lock, dropping it, then re-taking it to write loses
+    entries: two concurrent `log` calls both read the same ledger and the
+    second overwrites the first. This ledger also carries running aggregates
+    (total_cost, total_images, daily), so a lost write drops the entry and its
+    aggregate increment together and the file still looks self-consistent.
+
+    The lock lives in a separate .lock file on purpose. The atomic write
+    replaces the ledger's inode, so a lock held on the ledger itself would not
+    protect the replacement.
+    """
+    BANANA_DIR.mkdir(parents=True, exist_ok=True)
+    with open(LOCK_PATH, "a+") as lock_handle:
+        _lock(lock_handle, exclusive=write)
+        try:
+            ledger = _read_ledger()
+            yield ledger
+            if write:
+                _write_ledger(ledger)
+        finally:
+            _unlock(lock_handle)
+
+
+def _ledger_snapshot():
+    """Read the ledger under a shared lock. For read-only commands."""
+    with _locked_ledger() as ledger:
+        return ledger
 
 
 def _lookup_cost(model, resolution, batch=False):
@@ -76,7 +192,6 @@ def _lookup_cost(model, resolution, batch=False):
 
 def cmd_log(args):
     """Log a generation to the ledger."""
-    ledger = _load_ledger()
     cost = _lookup_cost(args.model, args.resolution, getattr(args, "batch", False))
     today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
     now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S")
@@ -89,23 +204,28 @@ def cmd_log(args):
         "prompt": args.prompt[:100],
     }
 
-    ledger["entries"].append(entry)
-    ledger["total_cost"] = round(ledger["total_cost"] + cost, 4)
-    ledger["total_images"] += 1
+    # Read and write inside one lock, so a concurrent log cannot overwrite this
+    # entry (and its aggregate increments) with a ledger it read beforehand.
+    with _locked_ledger(write=True) as ledger:
+        ledger["entries"].append(entry)
+        ledger["total_cost"] = round(ledger["total_cost"] + cost, 4)
+        ledger["total_images"] += 1
 
-    if today not in ledger["daily"]:
-        ledger["daily"][today] = {"count": 0, "cost": 0.0}
-    ledger["daily"][today]["count"] += 1
-    ledger["daily"][today]["cost"] = round(ledger["daily"][today]["cost"] + cost, 4)
+        if today not in ledger["daily"]:
+            ledger["daily"][today] = {"count": 0, "cost": 0.0}
+        ledger["daily"][today]["count"] += 1
+        ledger["daily"][today]["cost"] = round(ledger["daily"][today]["cost"] + cost, 4)
 
-    _save_ledger(ledger)
-    print(json.dumps({"logged": True, "cost": cost, "total_cost": ledger["total_cost"],
-                       "total_images": ledger["total_images"]}))
+        total_cost = ledger["total_cost"]
+        total_images = ledger["total_images"]
+
+    print(json.dumps({"logged": True, "cost": cost, "total_cost": total_cost,
+                       "total_images": total_images}))
 
 
 def cmd_summary(args):
     """Show cost summary."""
-    ledger = _load_ledger()
+    ledger = _ledger_snapshot()
     print(f"Total images: {ledger['total_images']}")
     print(f"Total cost:   ${ledger['total_cost']:.3f}")
     print()
@@ -124,7 +244,7 @@ def cmd_summary(args):
 
 def cmd_today(args):
     """Show today's usage."""
-    ledger = _load_ledger()
+    ledger = _ledger_snapshot()
     today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
     daily = ledger.get("daily", {}).get(today, {"count": 0, "cost": 0.0})
     print(f"Today ({today}): {daily['count']} images, ${daily['cost']:.3f}")
@@ -149,7 +269,16 @@ def cmd_reset(args):
     if not args.confirm:
         print("Error: Pass --confirm to reset the cost ledger.", file=sys.stderr)
         sys.exit(1)
-    _save_ledger({"total_cost": 0.0, "total_images": 0, "entries": [], "daily": {}})
+    # Takes the same exclusive lock as `log`, but deliberately does NOT read
+    # first: reset is the recovery path for a corrupt ledger, so it must not
+    # depend on the existing file parsing.
+    BANANA_DIR.mkdir(parents=True, exist_ok=True)
+    with open(LOCK_PATH, "a+") as lock_handle:
+        _lock(lock_handle, exclusive=True)
+        try:
+            _write_ledger(_empty_ledger())
+        finally:
+            _unlock(lock_handle)
     print("Cost ledger reset.")
 
 
@@ -184,7 +313,12 @@ def main():
     args = parser.parse_args()
     cmds = {"log": cmd_log, "summary": cmd_summary, "today": cmd_today,
             "estimate": cmd_estimate, "reset": cmd_reset}
-    cmds[args.command](args)
+    try:
+        cmds[args.command](args)
+    except LedgerError as exc:
+        # Fail closed and loudly rather than under-reporting spend.
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

`skills/banana/scripts/cost_tracker.py` reads and writes `~/.banana/costs.json` with no file
locking on any platform and a non-atomic write, so concurrent `log` calls silently lose
entries and can crash on a half-written file. This adds one exclusive lock spanning the whole
read-modify-write, an atomic write, a `msvcrt` fallback for Windows, and a fail-closed path
for a corrupt ledger.

### The bug

```python
def _load_ledger():
    with open(LEDGER_PATH, "r") as f:
        return json.load(f)

def _save_ledger(ledger):
    with open(LEDGER_PATH, "w") as f:      # truncates in place
        json.dump(ledger, f, indent=2)

def cmd_log(args):
    ledger = _load_ledger()                # read
    ...
    _save_ledger(ledger)                   # write
```

Two concurrent `log` calls both read the same ledger and the second overwrites the first:

```
P1 load -> [a,b,c]
P2 load -> [a,b,c]
P1 append d, save -> [a,b,c,d]
P2 append e, save -> [a,b,c,e]     # d is gone
```

**Measured on macOS** against `main`, 20 concurrent `log` calls: **4 entries lost**, and
**3 of those processes crashed outright** with `JSONDecodeError` after reading a half-written
file. So a concurrent batch can both under-report spend and kill generations mid-run. This is
not platform-specific.

### Why it is easy to miss

The ledger carries running aggregates (`total_cost`, `total_images`, `daily`) that are
incremented in the **same write** as the entry. A lost write therefore drops the entry *and*
its aggregate increments together, and the file stays internally self-consistent while
under-reporting. Checking that `total_cost` equals `sum(entries)` proves nothing: it was
still true in every run above, including the one that lost 4 entries.

### The fix

- **`_locked_ledger()`** holds one exclusive lock across the whole read-modify-write in
  `cmd_log`. Taking a lock to read, dropping it, then re-taking it to write would not be
  enough; the lock has to span both halves.
- **Cross-platform locking.** `fcntl` on POSIX, `msvcrt.locking` on Windows, and if neither
  is importable the operation raises rather than silently proceeding unlocked. A cost ledger
  that quietly drops entries is worse than one that refuses to run.
- **Atomic writes** via `tempfile.mkstemp` + `os.replace`, so a crash mid-write can never
  leave a truncated, unparseable ledger.
- **A corrupt ledger fails closed** with an actionable message instead of a bare traceback,
  and the file is left in place for inspection.
- **`cmd_reset` takes the lock but deliberately does not read first.** Reset is the recovery
  path for a corrupt ledger, so making it depend on the existing file parsing would leave a
  corrupt ledger unrecoverable through the CLI.
- **`BANANA_HOME`** overrides the ledger location, so the behaviour can be exercised without
  touching a real spend history.

The lock lives in a separate `costs.lock` file on purpose: the atomic write replaces the
ledger's inode, so a lock held on the ledger itself would not protect the replacement.

### Verification

Reproduced and confirmed against this branch with 20 concurrent `log` subprocesses writing
to an isolated `BANANA_HOME`:

| | entries retained | crashed processes |
|---|---|---|
| `main` | 15-16 of 20 | 2-3 of 20 |
| this branch | 20 of 20 | 0 |

The exact loss count varies run to run, which is what a race looks like; the branch has
returned 20 of 20 with zero crashes on every run.

The repo's four CI checks (`SKILL.md` line count, required files, `py_compile` over every
script, rate-limit grep) pass locally on the branch, and `install.sh` was re-run against a
sandboxed `HOME` with `cost_tracker.py` landing byte-identical.

No tests are included: the repo has no test suite or test runner today, and adding one felt
like a larger decision than this fix should make on your behalf. The equivalent fix in the
companion PR below carries 9 tests for exactly this file, and I am happy to port them here if
you would like a `tests/` directory.

### Note for maintainers

`AgriciDaniel/claude-seo` embeds a byte-identical copy of this tracker at
`extensions/banana/scripts/cost_tracker.py`, and both copies write the same
`~/.banana/costs.json`. Advisory locks only work when **every** writer takes them, so both
copies need the fix for either to be safe. A companion PR to `claude-seo` covers that copy
plus the same defect in its own DataForSEO spend ledger.

## Changes

- `skills/banana/scripts/cost_tracker.py` — one exclusive lock spanning the whole
  read-modify-write, atomic write, `msvcrt` fallback, fail-closed corrupt ledger,
  `BANANA_HOME` override.
- `CHANGELOG.md` — `Unreleased / Fixed` entry covering all of the above.

## Checklist

- [x] SKILL.md stays under 500 lines / 5,000 tokens — unmodified; still 375 lines.
- [x] Rate limits, model names, and aspect ratios are consistent across all files — none
  touched by this change; the CI rate-limit grep passes.
- [ ] `./install.sh` passes validation (9/9 checks) — **partially verified**, so left
  unticked rather than claimed. The install path was re-run against a sandboxed `HOME`:
  the skill copies cleanly and `cost_tracker.py` lands byte-identical to the branch. The 9
  validation checks themselves inspect the operator's MCP environment (`settings.json`,
  API key, `npx`, output directory), which a sandboxed home cannot satisfy and which this
  change does not touch. The repo's four CI checks do all pass on the branch.
- [x] No secrets or API keys committed — diff scanned; the only new strings are lock-file
  paths and error messages.
